### PR TITLE
Add Domain project and update project references

### DIFF
--- a/backend/FertileNotify.API/FertileNotify.API.csproj
+++ b/backend/FertileNotify.API/FertileNotify.API.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\FertileNotify.Application\FertileNotify.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/backend/FertileNotify.Application/FertileNotify.Application.csproj
+++ b/backend/FertileNotify.Application/FertileNotify.Application.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <ProjectReference Include="..\FertileNotify.Domain\FertileNotify.Domain.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/FertileNotify.Domain/README.md
+++ b/backend/FertileNotify.Domain/README.md
@@ -1,0 +1,7 @@
+# FertileNotify.Domain
+This project contains the core domain entities, value objects, and enums for the FertileNotify application. It defines the main business logic and rules that govern the notification system.
+
+## Project Structure
+- **Entities**: Contains the main domain entities such as `User`, `Notification`, `Event`, and `Subscription`.
+- **ValueObjects**: Contains value objects like `NotificationChannel` and `EventType` that encapsulate specific concepts in the domain.
+- **Enums**: Contains enumerations such as `NotificationStatus`, `SubscriptionPlan`, and `RetryStatus` that define various states and types used throughout the domain.

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <ProjectReference Include="..\FertileNotify.Application\FertileNotify.Application.csproj" />
+    <ProjectReference Include="..\FertileNotify.Domain\FertileNotify.Domain.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/FertileNotify.sln
+++ b/backend/FertileNotify.sln
@@ -3,10 +3,72 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Domain", "FertileNotify.Domain\FertileNotify.Domain.csproj", "{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.API", "FertileNotify.API\FertileNotify.API.csproj", "{D55E5B34-3415-42F3-948E-CD78C4AB92DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Application", "FertileNotify.Application\FertileNotify.Application.csproj", "{C3B8D071-EE4C-4193-9519-073840677F91}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Infrastructure", "FertileNotify.Infrastructure\FertileNotify.Infrastructure.csproj", "{246FDA89-390B-485D-9740-0C2CBB72F1DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Debug|x86.Build.0 = Debug|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|x64.Build.0 = Release|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{78BEF65D-ADF5-4087-871E-5B7D2E0850B0}.Release|x86.Build.0 = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|x64.Build.0 = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|x64.ActiveCfg = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|x64.Build.0 = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|x86.ActiveCfg = Release|Any CPU
+		{D55E5B34-3415-42F3-948E-CD78C4AB92DD}.Release|x86.Build.0 = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|x64.Build.0 = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Debug|x86.Build.0 = Debug|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|x64.ActiveCfg = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|x64.Build.0 = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|x86.ActiveCfg = Release|Any CPU
+		{C3B8D071-EE4C-4193-9519-073840677F91}.Release|x86.Build.0 = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|x64.Build.0 = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Debug|x86.Build.0 = Debug|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x64.ActiveCfg = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x64.Build.0 = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x86.ActiveCfg = Release|Any CPU
+		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduced the FertileNotify.Domain project with a README, updated the solution file to include all projects, and added necessary project references between API, Application, and Infrastructure layers to establish correct dependencies.