### PR TITLE
Refactor notification and user handling, add registration use case

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -1,5 +1,7 @@
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.UseCases.ProcessEvent;
+using FertileNotify.Application.UseCases.RegisterUser;
+using FertileNotify.Domain.Enums;
 using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
 
@@ -7,10 +9,33 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
-builder.Services.AddScoped<INotificationRepository, ConsoleNotificationSender>();
+builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<ISubscriptionRepository, InMemorySubscriptionRepository>();
 
 builder.Services.AddScoped<ProcessEventHandler>();
+
+// === TEST ===
+var userRepo = new InMemoryUserRepository();
+var subscriptionRepo = new InMemorySubscriptionRepository();
+var notificationSender = new ConsoleNotificationSender();
+
+var registerUserHandler = new RegisterUserHandler(userRepo, subscriptionRepo);
+var userId = await registerUserHandler.HandleAsync("test@test.com");
+
+Console.WriteLine($"Test User ID: {userId}");
+
+var processEvent = new ProcessEventHandler(
+    subscriptionRepo,
+    notificationSender
+);
+
+await processEvent.HandleAsync(new ProcessEventCommand
+{
+    UserId = userId,
+    EventType = "OrderCreated",
+    Payload = "Order #123 created"
+});
+// === END ===
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.Application/Interfaces/INotificationRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationRepository.cs
@@ -1,9 +1,0 @@
-using FertileNotify.Domain.Entities;
-
-namespace FertileNotify.Application.Interfaces
-{
-    public interface INotificationRepository
-    {
-        Task SendAsync(Notification notification);
-    }
-}

--- a/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
@@ -1,0 +1,7 @@
+namespace FertileNotify.Application.Interfaces
+{
+    public interface INotificationSender
+    {
+        Task SendAsync(string eventType, string payload);
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/IUserRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/IUserRepository.cs
@@ -1,0 +1,10 @@
+﻿using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface IUserRepository
+    {
+        Task SaveAsync(User user);
+        Task<User?> GetByIdAsync(Guid id);
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventCommand.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventCommand.cs
@@ -2,8 +2,8 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
 {
     public class ProcessEventCommand
     {
-        public Guid UserId { get; set; }
-        public string Title { get; set; } = string.Empty;
-        public string Message { get; set; } = string.Empty;
+        public Guid UserId { get; init; }
+        public string EventType { get; init; } = default!;
+        public string Payload { get; init; } = default!;
     }
 }

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -1,36 +1,35 @@
 using FertileNotify.Application.Interfaces;
-using FertileNotify.Domain.Entities;
 
 namespace FertileNotify.Application.UseCases.ProcessEvent
 {
     public class ProcessEventHandler
     {
         private readonly ISubscriptionRepository _subscriptionRepository;
-        private readonly INotificationRepository _notificationRepository;
+        private readonly INotificationSender _notificationSender;
 
         public ProcessEventHandler(
             ISubscriptionRepository subscriptionRepository,
-            INotificationRepository notificationRepository
+            INotificationSender notificationSender
         )
         {
             _subscriptionRepository = subscriptionRepository;
-            _notificationRepository = notificationRepository;
+            _notificationSender = notificationSender;
         }
 
         public async Task HandleAsync(ProcessEventCommand command)
         {
-            var subscription = await _subscriptionRepository.GetByIdAsync(command.UserId);
-            
-            if (subscription is null) 
-                throw new Exception("Subscription not found");
+            var subscription =
+                await _subscriptionRepository.GetByIdAsync(command.UserId)
+                ?? throw new Exception("Subscription not found");
 
             subscription.EnsureCanSendNotification();
 
-            var notification = new Notification(command.Title, command.Message);
-            await _notificationRepository.SendAsync(notification);
+            await _notificationSender.SendAsync(
+                command.EventType,
+                command.Payload
+            );
 
             subscription.IncreaseUsage();
-
             await _subscriptionRepository.SaveAsync(subscription);
         }
     }

--- a/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserCommand.cs
+++ b/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserCommand.cs
@@ -1,0 +1,15 @@
+﻿using FertileNotify.Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FertileNotify.Application.UseCases.RegisterUser
+{
+    public class RegisterUserCommand
+    {
+        public string Email { get; init; } = default!;
+        public SubscriptionPlan Plan { get; init; }
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserHandler.cs
@@ -1,0 +1,68 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FertileNotify.Application.UseCases.RegisterUser
+{
+    public class RegisterUserHandler
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly ISubscriptionRepository _subscriptionRepository;
+
+        public RegisterUserHandler(
+            IUserRepository userRepository,
+            ISubscriptionRepository subscriptionRepository
+        )
+        {
+            _userRepository = userRepository;
+            _subscriptionRepository = subscriptionRepository;
+        }
+
+        public async Task<Guid> HandleAsync(RegisterUserCommand command)
+        {
+            var user = new User(command.Email);
+
+            int monthlyLimit = command.Plan switch
+            {
+                SubscriptionPlan.Free => 10,
+                SubscriptionPlan.Pro => 100,
+                SubscriptionPlan.Enterprise => 1000,
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+
+            var subscription = new Subscription(
+                user.Id,
+                command.Plan,
+                monthlyLimit,
+                DateTime.UtcNow.AddMonths(1)
+            );
+
+            await _userRepository.SaveAsync(user);
+            await _subscriptionRepository.SaveAsync(subscription);
+
+            return user.Id;
+        }
+
+        public async Task<Guid> HandleAsync(string email)
+        {
+            var user = new User(email);
+
+            var subscription = new Subscription(
+                userId: user.Id,
+                plan: SubscriptionPlan.Free,
+                monthlyLimit: 10,
+                expiresAt: DateTime.UtcNow.AddMonths(1)
+            );
+
+            await _userRepository.SaveAsync(user);
+            await _subscriptionRepository.SaveAsync(subscription);
+
+            return user.Id;
+        }
+    }
+}

--- a/backend/FertileNotify.Domain/Entities/Subscription.cs
+++ b/backend/FertileNotify.Domain/Entities/Subscription.cs
@@ -6,14 +6,22 @@ namespace FertileNotify.Domain.Entities
     public class Subscription
     {
         public Guid Id { get; private set; }
+        public Guid UserId { get; private set; }
+
         public SubscriptionPlan Plan { get; private set; }
         public int MonthlyLimit { get; private set; }
         public int UsedThisMonth { get; private set; }
         public DateTime ExpiresAt { get; private set; }
 
-        public Subscription(SubscriptionPlan plan, int monthlyLimit, DateTime expiresAt)
+        public Subscription(
+            Guid userId, 
+            SubscriptionPlan plan, 
+            int monthlyLimit, 
+            DateTime expiresAt
+        )
         {
             Id = Guid.NewGuid();
+            UserId = userId;
             Plan = plan;
             MonthlyLimit = monthlyLimit;
             UsedThisMonth = 0;

--- a/backend/FertileNotify.Domain/Entities/User.cs
+++ b/backend/FertileNotify.Domain/Entities/User.cs
@@ -1,10 +1,16 @@
+using System;
+
 namespace FertileNotify.Domain.Entities
 {
     public class User
     {
-        public int Id { get; set; }
-        public string Username { get; set; }
-        public string Email { get; set; }
-        public DateTime CreatedAt { get; set; }
+        public Guid Id { get; private set; }
+        public string Email { get; private set; }
+
+        public User(string email)
+        {
+            Id = Guid.NewGuid();
+            Email = email;
+        }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
@@ -1,17 +1,12 @@
-﻿using FertileNotify.Domain.Entities;
-using FertileNotify.Application.Interfaces;
+﻿using FertileNotify.Application.Interfaces;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
-    public class ConsoleNotificationSender : INotificationRepository
+    public class ConsoleNotificationSender : INotificationSender
     {
-        public Task SendAsync(Notification notification)
+        public Task SendAsync(string eventType, string payload)
         {
-            Console.WriteLine($"=== Notification Sent ===");
-            Console.WriteLine($"ID: {notification.Id}");
-            Console.WriteLine($"Title: {notification.Title}");
-            Console.WriteLine($"Title: {notification.Message}");
-            Console.WriteLine($"Create At: {notification.CreateAt}");
+            Console.WriteLine($"[EVENT: {eventType}] {payload}");
             return Task.CompletedTask;
         }
     }

--- a/backend/FertileNotify.Infrastructure/Persistence/InMemorySubscriptionRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/InMemorySubscriptionRepository.cs
@@ -5,17 +5,19 @@ namespace FertileNotify.Infrastructure.Persistence
 {
     public class InMemorySubscriptionRepository : ISubscriptionRepository
     {
-        private readonly Dictionary<Guid, Subscription> _subscriptions = new();
+        private readonly Dictionary<Guid, Subscription> _storage = new();
 
         public Task<Subscription?> GetByIdAsync(Guid userId)
         {
-            _subscriptions.TryGetValue(userId, out var subscription);
+            var subscription = _storage.Values
+                .FirstOrDefault(s => s.UserId == userId);
+
             return Task.FromResult(subscription);
         }
 
         public Task SaveAsync(Subscription subscription)
         {
-            _subscriptions[subscription.Id] = subscription;
+            _storage[subscription.Id] = subscription;
             return Task.CompletedTask;
         }
     }

--- a/backend/FertileNotify.Infrastructure/Persistence/InMemoryUserRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/InMemoryUserRepository.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class InMemoryUserRepository : IUserRepository
+    {
+        private readonly Dictionary<Guid, User> _users = new();
+
+        public Task SaveAsync(User user)
+        {
+            _users[user.Id] = user;
+            return Task.CompletedTask;
+        }
+
+        public Task<User?> GetByIdAsync(Guid id)
+        {
+            _users.TryGetValue(id, out var user);
+            return Task.FromResult(user);
+        }
+    }
+}


### PR DESCRIPTION
Replaced INotificationRepository with INotificationSender and updated related implementations. Introduced IUserRepository and InMemoryUserRepository for user persistence. Added RegisterUserCommand and RegisterUserHandler to support user registration with subscription creation. Refactored ProcessEventCommand and ProcessEventHandler to use event types and payloads instead of notification entities. Updated Subscription and User entities to use Guid IDs.