### PR TITLE
Add user creation with subscription and refactor repositories

### DIFF
--- a/backend/FertileNotify.API/Controllers/UsersController.cs
+++ b/backend/FertileNotify.API/Controllers/UsersController.cs
@@ -1,0 +1,27 @@
+﻿using FertileNotify.Application.UseCases.CreateUserWithSubscription;
+using FertileNotify.Domain.Enums;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FertileNotify.API.Controllers
+{
+    [ApiController]
+    [Route("api/users")]
+    public class UsersController : ControllerBase
+    {
+        private readonly CreateUserHandler _createUserHandler;
+
+        public UsersController(CreateUserHandler createUserHandler)
+        {
+            _createUserHandler = createUserHandler;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create(CreateUserRequest request)
+        {
+            var userId = await _createUserHandler.HandleAsync(request.Email, request.Plan);
+            return Ok(new { UserId = userId });
+        }
+    }
+
+    public record CreateUserRequest(string Email, SubscriptionPlan Plan);
+}

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -1,41 +1,24 @@
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.UseCases.ProcessEvent;
-using FertileNotify.Application.UseCases.RegisterUser;
-using FertileNotify.Domain.Enums;
+using FertileNotify.Application.UseCases.CreateUserWithSubscription;
 using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 
-builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
+builder.Services.AddScoped<IUserRepository, InMemoryUserRepository>();
 builder.Services.AddScoped<ISubscriptionRepository, InMemorySubscriptionRepository>();
+builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 
+builder.Services.AddScoped<CreateUserHandler>();
 builder.Services.AddScoped<ProcessEventHandler>();
-
-// === TEST ===
-var userRepo = new InMemoryUserRepository();
-var subscriptionRepo = new InMemorySubscriptionRepository();
-var notificationSender = new ConsoleNotificationSender();
-
-var registerUserHandler = new RegisterUserHandler(userRepo, subscriptionRepo);
-var userId = await registerUserHandler.HandleAsync("test@test.com");
-
-Console.WriteLine($"Test User ID: {userId}");
-
-var processEvent = new ProcessEventHandler(
-    subscriptionRepo,
-    notificationSender
-);
-
-await processEvent.HandleAsync(new ProcessEventCommand
-{
-    UserId = userId,
-    EventType = "OrderCreated",
-    Payload = "Order #123 created"
-});
-// === END ===
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.Application/Interfaces/ISubscriptionRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/ISubscriptionRepository.cs
@@ -4,7 +4,7 @@ namespace FertileNotify.Application.Interfaces
 {
     public interface ISubscriptionRepository
     {
-        Task<Subscription?> GetByIdAsync(Guid userId);
-        Task SaveAsync(Subscription subscription);
+        Task SaveAsync(Guid userId, Subscription subscription);
+        Task<Subscription?> GetByUserIdAsync(Guid userId);
     }
 }

--- a/backend/FertileNotify.Application/UseCases/CreateUserWithSubscription/CreateUserCommand.cs
+++ b/backend/FertileNotify.Application/UseCases/CreateUserWithSubscription/CreateUserCommand.cs
@@ -1,0 +1,10 @@
+﻿using FertileNotify.Domain.Enums;
+
+namespace FertileNotify.Application.UseCases.CreateUserWithSubscription
+{
+    public class CreateUserCommand
+    {
+        public  string Email { get; set; } = string.Empty;
+        public SubscriptionPlan Plan { get; set; }
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/CreateUserWithSubscription/CreateUserHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/CreateUserWithSubscription/CreateUserHandler.cs
@@ -1,0 +1,34 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
+
+namespace FertileNotify.Application.UseCases.CreateUserWithSubscription
+{
+    public class CreateUserHandler
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly ISubscriptionRepository _subscriptionRepository;
+
+        public CreateUserHandler(IUserRepository userRepository, ISubscriptionRepository subscriptionRepository)
+        {
+            _userRepository = userRepository;
+            _subscriptionRepository = subscriptionRepository;
+        }
+
+        public async Task<Guid> HandleAsync(string email, SubscriptionPlan plan)
+        {
+            var user = new User(email);
+            await _userRepository.SaveAsync(user);
+
+            var subscription = new Subscription(
+                user.Id,
+                plan,
+                plan == SubscriptionPlan.Free ? 10 : 100,
+                DateTime.UtcNow.AddMonths(1)
+            );
+            await _subscriptionRepository.SaveAsync(user.Id, subscription);
+
+            return user.Id;
+        }
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -19,7 +19,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
         public async Task HandleAsync(ProcessEventCommand command)
         {
             var subscription =
-                await _subscriptionRepository.GetByIdAsync(command.UserId)
+                await _subscriptionRepository.GetByUserIdAsync(command.UserId)
                 ?? throw new Exception("Subscription not found");
 
             subscription.EnsureCanSendNotification();
@@ -30,7 +30,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
             );
 
             subscription.IncreaseUsage();
-            await _subscriptionRepository.SaveAsync(subscription);
+            await _subscriptionRepository.SaveAsync(command.UserId, subscription);
         }
     }
 }

--- a/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/RegisterUser/RegisterUserHandler.cs
@@ -1,11 +1,6 @@
 ﻿using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FertileNotify.Application.UseCases.RegisterUser
 {
@@ -43,7 +38,7 @@ namespace FertileNotify.Application.UseCases.RegisterUser
             );
 
             await _userRepository.SaveAsync(user);
-            await _subscriptionRepository.SaveAsync(subscription);
+            await _subscriptionRepository.SaveAsync(user.Id, subscription);
 
             return user.Id;
         }
@@ -60,7 +55,7 @@ namespace FertileNotify.Application.UseCases.RegisterUser
             );
 
             await _userRepository.SaveAsync(user);
-            await _subscriptionRepository.SaveAsync(subscription);
+            await _subscriptionRepository.SaveAsync(user.Id, subscription);
 
             return user.Id;
         }

--- a/backend/FertileNotify.Domain/Entities/User.cs
+++ b/backend/FertileNotify.Domain/Entities/User.cs
@@ -1,11 +1,11 @@
-using System;
-
 namespace FertileNotify.Domain.Entities
 {
     public class User
     {
         public Guid Id { get; private set; }
         public string Email { get; private set; }
+
+        private User() { }
 
         public User(string email)
         {

--- a/backend/FertileNotify.Infrastructure/Persistence/InMemorySubscriptionRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/InMemorySubscriptionRepository.cs
@@ -5,20 +5,18 @@ namespace FertileNotify.Infrastructure.Persistence
 {
     public class InMemorySubscriptionRepository : ISubscriptionRepository
     {
-        private readonly Dictionary<Guid, Subscription> _storage = new();
+        private static readonly Dictionary<Guid, Subscription> _subscriptions = new();
 
-        public Task<Subscription?> GetByIdAsync(Guid userId)
+        public Task SaveAsync(Guid userId, Subscription subscription)
         {
-            var subscription = _storage.Values
-                .FirstOrDefault(s => s.UserId == userId);
-
-            return Task.FromResult(subscription);
+            _subscriptions[userId] = subscription;
+            return Task.CompletedTask;
         }
 
-        public Task SaveAsync(Subscription subscription)
+        public Task<Subscription?> GetByUserIdAsync(Guid userId)
         {
-            _storage[subscription.Id] = subscription;
-            return Task.CompletedTask;
+            _subscriptions.TryGetValue(userId, out var sub);
+            return Task.FromResult(sub);
         }
     }
 }


### PR DESCRIPTION
Introduced UsersController and CreateUserHandler to support user creation with subscription plan selection. Refactored ISubscriptionRepository and InMemorySubscriptionRepository to use userId as key and updated method signatures accordingly. Updated related use cases and handlers to align with the new repository interface. Improved enum serialization in API responses.