### PR TITLE
Add notification template support with template engine

### DIFF
--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -19,21 +19,18 @@ namespace FertileNotify.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Send([FromBody] SendNotificationRequest request)
         {
+            if (request == null)
+                return BadRequest(new { error = "Request body is required." });
+
             EventType eventType;
-            try
-            {
-                eventType = EventType.From(request.EventType);
-            }
-            catch
-            {
-                return BadRequest(new { error = $"Invalid event type: {request.EventType}" });
-            }
+            try { eventType = EventType.From(request.EventType); }
+            catch { return BadRequest(new { error = $"Invalid event type: {request.EventType}" }); }
 
             var command = new ProcessEventCommand
             {
                 UserId = request.UserId,
                 EventType = eventType,
-                Payload = request.Payload,
+                Parameters = request.Parameters
             };
 
             try

--- a/backend/FertileNotify.API/Models/SendNotificationRequest.cs
+++ b/backend/FertileNotify.API/Models/SendNotificationRequest.cs
@@ -4,6 +4,6 @@
     {
         public Guid UserId { get; set; } = default(Guid);
         public string EventType { get; set; } = string.Empty;
-        public string Payload { get; set; } = string.Empty;
+        public Dictionary<string, string> Parameters { get; set; } = new();
     }
 }

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -1,6 +1,7 @@
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.UseCases.ProcessEvent;
 using FertileNotify.Application.UseCases.RegisterUser;
+using FertileNotify.Application.Services;
 using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
 using System.Text.Json.Serialization;
@@ -15,6 +16,7 @@ builder.Services.AddControllers()
 
 builder.Services.AddSingleton<IUserRepository, InMemoryUserRepository>();
 builder.Services.AddSingleton<ISubscriptionRepository, InMemorySubscriptionRepository>();
+builder.Services.AddSingleton<ITemplateRepository, InMemoryTemplateRepository>();
 
 builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
@@ -22,6 +24,8 @@ builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
 
 builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterUserHandler>();
+
+builder.Services.AddScoped<TemplateEngine>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
@@ -1,0 +1,11 @@
+﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface ITemplateRepository
+    {
+        Task<NotificationTemplate?> GetByEventTypeAsync(EventType eventType);
+        Task AddAsync(NotificationTemplate template);
+    }
+}

--- a/backend/FertileNotify.Application/Services/TemplateEngine.cs
+++ b/backend/FertileNotify.Application/Services/TemplateEngine.cs
@@ -1,0 +1,19 @@
+﻿namespace FertileNotify.Application.Services
+{
+    public class TemplateEngine
+    {
+        public string Render(string template, Dictionary<string, string> parameters)
+        {
+            if (string.IsNullOrWhiteSpace(template))
+                throw new ArgumentException("Template cannot be null or empty.", nameof(template));
+            if (parameters == null || parameters.Count == 0) return template;
+
+            string rendered = template;
+            foreach (var param in parameters)
+            {
+                rendered = rendered.Replace($"{{{param.Key}}}", param.Value);
+            }
+            return rendered;
+        }
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventCommand.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventCommand.cs
@@ -6,6 +6,6 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
     {
         public Guid UserId { get; init; }
         public EventType EventType { get; set; } = default!;
-        public string Payload { get; set; } = string.Empty;
+        public Dictionary<string, string> Parameters { get; set; } = new();
     }
 }

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -1,4 +1,5 @@
 using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Services;
 
 namespace FertileNotify.Application.UseCases.ProcessEvent
 {
@@ -7,16 +8,22 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
         private readonly ISubscriptionRepository _subscriptionRepository;
         private readonly IUserRepository _userRepository;
         private readonly IEnumerable<INotificationSender> _senders;
+        private readonly ITemplateRepository _templateRepository;
+        private readonly TemplateEngine templateEngine;
 
         public ProcessEventHandler(
             ISubscriptionRepository subscriptionRepository,
             IUserRepository userRepository,
-            IEnumerable<INotificationSender> senders
+            IEnumerable<INotificationSender> senders,
+            ITemplateRepository templateRepository,
+            TemplateEngine templateEngine
         )
         {
             _subscriptionRepository = subscriptionRepository;
             _userRepository = userRepository;
             _senders = senders;
+            _templateRepository = templateRepository;
+            this.templateEngine = templateEngine;
         }
 
         public async Task HandleAsync(ProcessEventCommand command)
@@ -33,15 +40,36 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
 
             subscription.EnsureCanSendNotification();
 
+            var template = 
+                await _templateRepository.GetByEventTypeAsync(command.EventType) 
+                ?? throw new Exception("Notification template not found");
+            string subject = command.EventType.Name;
+            string body = "No template available." ?? string.Empty;
+
+            if (template != null)
+            {
+                subject = templateEngine.Render(template.SubjectTemplate, command.Parameters);
+                body = templateEngine.Render(template.BodyTemplate, command.Parameters);
+            }
+            else
+            {
+                body = string.Join(Environment.NewLine, command.Parameters.Select(kv => $"{kv.Key}: {kv.Value}"));
+            }
+
+            bool handled = false;
             foreach (var channel in user.ActiveChannels)
             {
                 var sender = _senders.FirstOrDefault(s => s.Channel.Equals(channel));
                 if (sender == null) continue;
-                await sender.SendAsync(user, command.EventType.Name, command.Payload);
+                await sender.SendAsync(user, subject, body);
+                handled = true;
             }
 
-            subscription.IncreaseUsage();
-            await _subscriptionRepository.SaveAsync(command.UserId, subscription);
+            if (!handled)
+            {
+                subscription.IncreaseUsage();
+                await _subscriptionRepository.SaveAsync(command.UserId, subscription);
+            }
         }
     }
 }

--- a/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
@@ -1,0 +1,30 @@
+﻿using FertileNotify.Domain.Events;
+
+namespace FertileNotify.Domain.Entities
+{
+    public class NotificationTemplate
+    {
+        public Guid Id { get; private set; }
+        public EventType EventType { get; private set; } = default!;
+        public string SubjectTemplate { get; private set; } = string.Empty;
+        public string BodyTemplate { get; private set; } = string.Empty;
+
+        private NotificationTemplate(EventType eventType, string subject, string body) 
+        {
+            Id = Guid.NewGuid();
+            EventType = eventType;
+            SubjectTemplate = subject;
+            BodyTemplate = body;
+        }
+
+        public static NotificationTemplate Create(EventType eventType, string subject, string body)
+        {
+            if (string.IsNullOrWhiteSpace(subject))
+                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
+            if (string.IsNullOrWhiteSpace(body))
+                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
+
+            return new NotificationTemplate(eventType, subject, body);
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/InMemoryTemplateRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/InMemoryTemplateRepository.cs
@@ -1,0 +1,35 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class InMemoryTemplateRepository : ITemplateRepository
+    {
+        private readonly List<NotificationTemplate> _templates = new();
+
+        public InMemoryTemplateRepository() 
+        {
+            _templates.Add(NotificationTemplate.Create(
+                EventType.UserRegistered, 
+                "Welcome, {Name}!", 
+                "Hello {Name}, thank you for registering at our site. Your email: {Email}"));
+
+            _templates.Add(NotificationTemplate.Create(
+                EventType.OrderCreated,
+                "Order Created",
+                "Hello {Name}, your order has been created."));
+        }
+
+        public Task AddAsync(NotificationTemplate template)
+        {
+            _templates.Add(template);
+            return Task.CompletedTask;
+        }
+
+        public Task<NotificationTemplate?> GetByEventTypeAsync(EventType eventType)
+        {
+            return Task.FromResult(_templates.FirstOrDefault(t => t.EventType.Equals(eventType)));
+        }
+    }
+}


### PR DESCRIPTION
Introduces a template engine and repository for notification templates, enabling dynamic rendering of notification subjects and bodies based on event parameters. Updates the notification sending flow to use templates, modifies API and command models to accept parameters instead of a payload string, and adds in-memory storage for templates.