### PR TITLE
Add background notification queue and worker

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -5,6 +5,7 @@ using FertileNotify.Application.Services;
 using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
 using System.Text.Json.Serialization;
+using FertileNotify.Infrastructure.BackgroundJobs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,6 +19,8 @@ builder.Services.AddSingleton<IUserRepository, InMemoryUserRepository>();
 builder.Services.AddSingleton<ISubscriptionRepository, InMemorySubscriptionRepository>();
 builder.Services.AddSingleton<ITemplateRepository, InMemoryTemplateRepository>();
 
+builder.Services.AddSingleton<INotificationQueue, InMemoryNotificationQueue>();
+
 builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
@@ -26,6 +29,8 @@ builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterUserHandler>();
 
 builder.Services.AddScoped<TemplateEngine>();
+
+builder.Services.AddHostedService<NotificationWorker>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.Application/Interfaces/INotificationQueue.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationQueue.cs
@@ -1,0 +1,10 @@
+﻿using FertileNotify.Application.UseCases.ProcessEvent;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface INotificationQueue
+    {
+        ValueTask QueueBackgroundWorkItemAsync(ProcessEventCommand workItem);
+        ValueTask<ProcessEventCommand> DequeueAsync(CancellationToken cancellationToken);
+    }
+}

--- a/backend/FertileNotify.Infrastructure/BackgroundJobs/InMemoryNotificationQueue.cs
+++ b/backend/FertileNotify.Infrastructure/BackgroundJobs/InMemoryNotificationQueue.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.UseCases.ProcessEvent;
+
+namespace FertileNotify.Infrastructure.BackgroundJobs
+{
+    public class InMemoryNotificationQueue : INotificationQueue
+    {
+        private readonly Channel<ProcessEventCommand> _queue;
+
+        public InMemoryNotificationQueue()
+        {
+            var options = new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            };
+            _queue = Channel.CreateUnbounded<ProcessEventCommand>(options);
+        }
+
+        public async ValueTask<ProcessEventCommand> DequeueAsync(CancellationToken cancellationToken)
+        {
+            return await _queue.Reader.ReadAsync(cancellationToken);
+        }
+
+        public async ValueTask QueueBackgroundWorkItemAsync(ProcessEventCommand workItem)
+        {
+            if (workItem == null)
+                throw new ArgumentNullException(nameof(workItem));
+
+            await _queue.Writer.WriteAsync(workItem);
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/BackgroundJobs/NotificationWorker.cs
+++ b/backend/FertileNotify.Infrastructure/BackgroundJobs/NotificationWorker.cs
@@ -1,0 +1,44 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.UseCases.ProcessEvent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FertileNotify.Infrastructure.BackgroundJobs
+{
+    public class NotificationWorker : BackgroundService
+    {
+        private readonly INotificationQueue _queue;
+        private readonly IServiceProvider _serviceProvider;
+
+        public NotificationWorker(INotificationQueue queue, IServiceProvider serviceProvider)
+        {
+            _queue = queue;
+            _serviceProvider = serviceProvider;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            Console.WriteLine("[WORKER] Background service has started...");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var command = await _queue.DequeueAsync(stoppingToken);
+
+                    Console.WriteLine($"[WORKER] New job received: {command.EventType.Name} -> {command.UserId}");
+
+                    using (var scope = _serviceProvider.CreateScope())
+                    {
+                        var handler = scope.ServiceProvider.GetRequiredService<ProcessEventHandler>();
+                        await handler.HandleAsync(command);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[WORKER ERROR] An error occurred while processing: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\FertileNotify.Domain\FertileNotify.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj.Backup.tmp
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj.Backup.tmp
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FertileNotify.Application\FertileNotify.Application.csproj" />
+    <ProjectReference Include="..\FertileNotify.Domain\FertileNotify.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Introduces an in-memory notification queue and a background worker to process notification events asynchronously. Refactors NotificationsController to enqueue notification commands instead of processing them directly. Registers the new queue and worker in the dependency injection container and updates project references as needed.