### PR TITLE
Add unit tests and fix notification logic

### DIFF
--- a/backend/FertileNotify.Application/Services/TemplateEngine.cs
+++ b/backend/FertileNotify.Application/Services/TemplateEngine.cs
@@ -4,8 +4,9 @@
     {
         public string Render(string template, Dictionary<string, string> parameters)
         {
-            if (string.IsNullOrWhiteSpace(template))
-                throw new ArgumentException("Template cannot be null or empty.", nameof(template));
+            if (string.IsNullOrEmpty(template))
+                return string.Empty;
+
             if (parameters == null || parameters.Count == 0) return template;
 
             string rendered = template;

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -65,7 +65,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
                 handled = true;
             }
 
-            if (!handled)
+            if (handled)
             {
                 subscription.IncreaseUsage();
                 await _subscriptionRepository.SaveAsync(command.UserId, subscription);

--- a/backend/FertileNotify.Domain/Entities/User.cs
+++ b/backend/FertileNotify.Domain/Entities/User.cs
@@ -23,7 +23,7 @@ namespace FertileNotify.Domain.Entities
             Email = email;
             PhoneNumber = phoneNumber;
 
-            _activeChannels.Add(NotificationChannel.Console);
+            _activeChannels.Add(NotificationChannel.Email);
         }
 
         public void EnableChannel(NotificationChannel channel)

--- a/backend/FertileNotify.Tests/FertileNotify.Tests.csproj
+++ b/backend/FertileNotify.Tests/FertileNotify.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FertileNotify.Application\FertileNotify.Application.csproj" />
+    <ProjectReference Include="..\FertileNotify.Domain\FertileNotify.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -1,0 +1,106 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Services;
+using FertileNotify.Application.UseCases.ProcessEvent;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using Moq;
+
+namespace FertileNotify.Tests
+{
+    public class ProcessEventHandlerTests
+    {
+        private readonly Mock<ISubscriptionRepository> _mockSubRepo;
+        private readonly Mock<IUserRepository> _mockUserRepo;
+        private readonly Mock<ITemplateRepository> _mockTemplateRepo;
+        private readonly Mock<INotificationSender> _mockEmailSender;
+        private readonly TemplateEngine _templateEngine;
+
+        private readonly ProcessEventHandler _handler;
+
+        public ProcessEventHandlerTests()
+        {
+            _mockSubRepo = new Mock<ISubscriptionRepository>();
+            _mockUserRepo = new Mock<IUserRepository>();
+            _mockTemplateRepo = new Mock<ITemplateRepository>();
+            _mockEmailSender = new Mock<INotificationSender>();
+
+            _mockEmailSender.Setup(x => x.Channel).Returns(NotificationChannel.Email);
+            var senders = new List<INotificationSender> { _mockEmailSender.Object };
+
+            _templateEngine = new TemplateEngine();
+
+            _handler = new ProcessEventHandler(
+                _mockSubRepo.Object,
+                _mockUserRepo.Object,
+                senders,
+                _mockTemplateRepo.Object,
+                _templateEngine
+            );
+        }
+
+        [Fact]
+        public async Task HandleAsync_Should_Send_Notification_When_Rules_Are_Valid()
+        {
+            var userId = Guid.NewGuid();
+            var command = new ProcessEventCommand
+            {
+                UserId = userId,
+                EventType = EventType.UserRegistered,
+                Parameters = new Dictionary<string, string> { { "Name", "TestUser" } }
+            };
+
+            var user = new User(EmailAddress.Create("test@test.com"), new PhoneNumber("0"));
+            _mockUserRepo.Setup(x => x.GetByIdAsync(userId)).ReturnsAsync(user);
+
+            var subscription = Subscription.Create(userId, SubscriptionPlan.Free);
+            _mockSubRepo.Setup(x => x.GetByUserIdAsync(userId)).ReturnsAsync(subscription);
+
+            var template = NotificationTemplate.Create(EventType.UserRegistered, "Subject {Name}", "Body");
+            _mockTemplateRepo.Setup(x => x.GetByEventTypeAsync(EventType.UserRegistered)).ReturnsAsync(template);
+
+            _mockEmailSender
+                .Setup(x => x.SendAsync(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            await _handler.HandleAsync(command);
+
+            _mockEmailSender.Verify(
+                x => x.SendAsync(
+                    It.IsAny<User>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ),
+                Times.Once,
+                "An email must be sent.");
+
+            _mockSubRepo.Verify(
+                x => x.SaveAsync(userId, It.IsAny<Subscription>()),
+                Times.Once,
+                "The subscription needs to be updated and saved.");
+        }
+
+        [Fact]
+        public async Task HandleAsync_Should_Not_Send_When_Subscription_Expired()
+        {
+            var userId = Guid.NewGuid();
+            var command = new ProcessEventCommand { UserId = userId, EventType = EventType.UserRegistered };
+
+            var user = new User(EmailAddress.Create("test@test.com"), new PhoneNumber("0-0-0-0-"));
+            _mockUserRepo.Setup(x => x.GetByIdAsync(userId)).ReturnsAsync(user);
+
+            var subscription = Subscription.Create(userId, SubscriptionPlan.Free);
+
+            var invalidCommand = new ProcessEventCommand { UserId = userId, EventType = EventType.OrderCreated };
+
+            _mockSubRepo.Setup(x => x.GetByUserIdAsync(userId)).ReturnsAsync(subscription);
+
+            await _handler.HandleAsync(invalidCommand);
+
+            _mockEmailSender.Verify(
+                x => x.SendAsync(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Never);
+        }
+    }
+}

--- a/backend/FertileNotify.Tests/TemplateEngineTests.cs
+++ b/backend/FertileNotify.Tests/TemplateEngineTests.cs
@@ -1,0 +1,44 @@
+﻿using FertileNotify.Application.Services;
+using FluentAssertions;
+
+namespace FertileNotify.Tests
+{
+    public class TemplateEngineTests
+    {
+        [Fact]
+        public void Render_Should_Replace_Placeholders_With_Values()
+        {
+            var engine = new TemplateEngine();
+            string template = "Hello {Name}, order no: {OrderId}";
+            var parameters = new Dictionary<string, string>
+            {
+                { "Name", "Enes" },
+                { "OrderId", "12345" }
+            };
+
+            var result = engine.Render(template, parameters);
+
+            result.Should().Be("Merhaba Enes, order no: 12345");
+        }
+
+        [Fact]
+        public void Render_Should_Return_Template_AsIs_When_Parameters_Are_Empty()
+        {
+            var engine = new TemplateEngine();
+            string template = "Hello {Name}";
+            var parameters = new Dictionary<string, string>();
+
+            var result = engine.Render(template, parameters);
+
+            result.Should().Be("Hello {Name}");
+        }
+
+        [Fact]
+        public void Render_Should_Handle_Null_Template()
+        {
+            var engine = new TemplateEngine();
+            var result = engine.Render(string.Empty, new Dictionary<string, string>());
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/backend/FertileNotify.sln
+++ b/backend/FertileNotify.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Application",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Infrastructure", "FertileNotify.Infrastructure\FertileNotify.Infrastructure.csproj", "{246FDA89-390B-485D-9740-0C2CBB72F1DD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FertileNotify.Tests", "FertileNotify.Tests\FertileNotify.Tests.csproj", "{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x64.Build.0 = Release|Any CPU
 		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x86.ActiveCfg = Release|Any CPU
 		{246FDA89-390B-485D-9740-0C2CBB72F1DD}.Release|x86.Build.0 = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|x64.Build.0 = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1BDCC63-E369-41FF-BAFB-8C00E0A9E3AE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduced FertileNotify.Tests project with unit tests for TemplateEngine and ProcessEventHandler. Fixed TemplateEngine to return empty string for null/empty templates instead of throwing, and corrected ProcessEventHandler logic to update subscription only when handled. Changed default notification channel in User entity from Console to Email. Updated solution file to include the new test project.