### PR TITLE
Refactor authentication to use email and improve error handling

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -1,6 +1,8 @@
 using System;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Exceptions;
+using FertileNotify.Domain.ValueObjects;
+using FertileNotify.API.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FertileNotify.API.Controllers
@@ -21,18 +23,13 @@ namespace FertileNotify.API.Controllers
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
-            var user = 
-                await _userRepository.GetByIdAsync(request.UserId)
+            var user =
+                await _userRepository.GetByEmailAsync(EmailAddress.Create(request.Email))
                 ?? throw new NotFoundException("User not found");
 
             var token = _tokenService.GenerateToken(user);
 
             return Ok( new { Token = token } );
         }
-    }
-
-    public class LoginRequest
-    {
-        public Guid UserId { get; set; } // ! Kullanıcılar bellekte tutuluyor. Bu yüzden şimdilik Guid ile kullanıcı bulunsun.
     }
 }

--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -5,6 +5,7 @@ using FertileNotify.Domain.Events;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Exceptions;
 using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
 
 namespace FertileNotify.API.Controllers
 {
@@ -25,12 +26,12 @@ namespace FertileNotify.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Send([FromBody] SendNotificationRequest request)
         {
-            if (!await _userRepository.ExistsAsync(request.UserId)) 
-                throw new NotFoundException("User not found");
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier) 
+                ?? throw new UnauthorizedException("User ID claim not found.");
 
             var command = new ProcessEventCommand
             {
-                UserId = request.UserId,
+                UserId = Guid.Parse(userIdClaim.Value),
                 EventType = EventType.From(request.EventType),
                 Parameters = request.Parameters
             };

--- a/backend/FertileNotify.API/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/backend/FertileNotify.API/Middlewares/ExceptionHandlingMiddleware.cs
@@ -49,6 +49,11 @@ namespace FertileNotify.API.Middlewares
                     message = ex.Message;
                     break;
 
+                case UnauthorizedException:
+                    status = HttpStatusCode.Unauthorized;
+                    message = ex.Message;
+                    break;
+
                 default:
                     _logger.LogError(ex, "Unexpected error: {Message}", ex.Message);
                     break;

--- a/backend/FertileNotify.API/Models/LoginRequest.cs
+++ b/backend/FertileNotify.API/Models/LoginRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class LoginRequest
+    {
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Models/SendNotificationRequest.cs
+++ b/backend/FertileNotify.API/Models/SendNotificationRequest.cs
@@ -2,7 +2,6 @@
 {
     public class SendNotificationRequest
     {
-        public Guid UserId { get; set; } = default(Guid);
         public string EventType { get; set; } = string.Empty;
         public Dictionary<string, string> Parameters { get; set; } = new();
     }

--- a/backend/FertileNotify.Application/Interfaces/IUserRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/IUserRepository.cs
@@ -1,4 +1,5 @@
 ﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.ValueObjects;
 
 namespace FertileNotify.Application.Interfaces
 {
@@ -6,6 +7,7 @@ namespace FertileNotify.Application.Interfaces
     {
         Task SaveAsync(User user);
         Task<User?> GetByIdAsync(Guid id);
+        Task<User?> GetByEmailAsync(EmailAddress email);
         Task<bool> ExistsAsync(Guid id);
     }
 }

--- a/backend/FertileNotify.Domain/Exceptions/UnauthorizedException.cs
+++ b/backend/FertileNotify.Domain/Exceptions/UnauthorizedException.cs
@@ -1,0 +1,7 @@
+﻿namespace FertileNotify.Domain.Exceptions
+{
+    public class UnauthorizedException : Exception
+    {
+        public UnauthorizedException(string message) : base(message) { }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/EfUserRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfUserRepository.cs
@@ -1,5 +1,6 @@
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
 
 namespace FertileNotify.Infrastructure.Persistence
@@ -28,13 +29,12 @@ namespace FertileNotify.Infrastructure.Persistence
         }
 
         public async Task<User?> GetByIdAsync(Guid id)
-        {
-            return await _context.Users.FirstOrDefaultAsync(u => u.Id == id);
-        }
+            => await _context.Users.FirstOrDefaultAsync(u => u.Id == id);
+
+        public async Task<User?> GetByEmailAsync(EmailAddress email)
+            => await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
 
         public async Task<bool> ExistsAsync(Guid id)
-        {
-            return await _context.Users.AnyAsync(u => u.Id == id);
-        }
+            => await _context.Users.AnyAsync(u => u.Id == id);
     }
 }


### PR DESCRIPTION
Login now uses email instead of user ID, with related changes to the LoginRequest model and repository interface. Notification sending retrieves user ID from claims, removing it from the request model. Added UnauthorizedException and updated middleware to handle it. Improved repository methods for cleaner async usage.