### PR TITLE
Add health checks with PostgreSQL support

### DIFF
--- a/backend/FertileNotify.API/FertileNotify.API.csproj
+++ b/backend/FertileNotify.API/FertileNotify.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
@@ -15,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -4,6 +4,8 @@ using FluentValidation.AspNetCore;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
 using System.Text;
 using Serilog;
 
@@ -16,8 +18,6 @@ using FertileNotify.Infrastructure.Persistence;
 using FertileNotify.Infrastructure.BackgroundJobs;
 using FertileNotify.Infrastructure.Authentication;
 using FertileNotify.API.Middlewares;
-using Microsoft.AspNetCore.RateLimiting;
-using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -55,6 +55,9 @@ builder.Services.AddControllers()
 // --- 2. Database ve EF Core ---
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!);
 
 // --- 3. Repositories ---
 builder.Services.AddScoped<ISubscriberRepository, EfSubscriberRepository>();
@@ -117,4 +120,7 @@ app.UseAuthorization();
 app.UseSerilogRequestLogging();
 
 app.MapControllers();
+
+app.MapHealthChecks("/health");
+
 app.Run();


### PR DESCRIPTION
Introduced health check endpoints to the API by adding AspNetCore.HealthChecks.NpgSql and Microsoft.Extensions.Diagnostics.HealthChecks packages. Registered health checks for the PostgreSQL database and mapped the /health endpoint in Program.cs.