### PR TITLE
Enable CORS with AllowAll policy

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -33,6 +33,16 @@ Log.Logger = new LoggerConfiguration()
 
 builder.Host.UseSerilog();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", builder =>
+    {
+        builder.AllowAnyOrigin()
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+
 builder.Services.AddRateLimiter(options =>
 {
     options.AddFixedWindowLimiter(policyName: "fixed", opt =>
@@ -153,6 +163,8 @@ await DbSeeder.SeedAsync(app);
 app.UseRateLimiter();
 
 app.UseMiddleware<ExceptionHandlingMiddleware>();
+
+app.UseCors("AllowAll");
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
Added a CORS policy named 'AllowAll' to permit any origin, method, and header. Applied the policy in the middleware pipeline to support cross-origin requests.