### PR TITLE
Add API key management and authentication

### DIFF
--- a/backend/FertileNotify.API/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/backend/FertileNotify.API/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,55 @@
+﻿using FertileNotify.Application.Interfaces;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using System.Text.Encodings.Web;
+using System.Security.Cryptography;
+using System.Text;
+using System.Security.Claims;
+
+namespace FertileNotify.API.Authentication
+{
+    public class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions { }
+
+    public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationOptions>
+    {
+        private readonly IApiKeyRepository _apiKeyRepository;
+
+        public ApiKeyAuthenticationHandler(
+            IOptionsMonitor<ApiKeyAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            IApiKeyRepository apiKeyRepository)
+            : base(options, logger, encoder)
+        {
+            _apiKeyRepository = apiKeyRepository;
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("FN-Api-Key", out var extractedApiKey))
+                AuthenticateResult.NoResult();
+
+            var providedKey = extractedApiKey.ToString();
+
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(providedKey));
+            var hash = Convert.ToBase64String(hashBytes);
+
+            var apiKey = await _apiKeyRepository.GetByKeyHashAsync(hash);
+            if (apiKey == null)
+                return AuthenticateResult.Fail("Invalid API Key");
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, apiKey.SubscriberId.ToString()),
+                new Claim("ApiKeyId", apiKey.Id.ToString())
+            };
+
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+            return AuthenticateResult.Success(ticket);
+        }
+    }
+}

--- a/backend/FertileNotify.API/Models/ApiKeyDto.cs
+++ b/backend/FertileNotify.API/Models/ApiKeyDto.cs
@@ -1,0 +1,11 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class ApiKeyDto
+    {
+        public Guid Id { get; set; }
+        public string Prefix { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/backend/FertileNotify.API/Models/CreateApiKeyRequest.cs
+++ b/backend/FertileNotify.API/Models/CreateApiKeyRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class CreateApiKeyRequest
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Validators/CreateApiKeyRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateApiKeyRequestValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using FertileNotify.API.Models;
+
+namespace FertileNotify.API.Validators
+{
+    public class CreateApiKeyRequestValidator : AbstractValidator<CreateApiKeyRequest>
+    {
+        public CreateApiKeyRequestValidator()
+        {
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("API key name is required.");
+        }
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/IApiKeyRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/IApiKeyRepository.cs
@@ -1,0 +1,11 @@
+﻿using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface IApiKeyRepository
+    {
+        Task SaveAsync(ApiKey apiKey);
+        Task<ApiKey?> GetByKeyHashAsync(string keyHash);
+        Task<List<ApiKey>> GetBySubscriberIdAsync(Guid subscriberId);
+    }
+}

--- a/backend/FertileNotify.Application/Services/ApiKeyService.cs
+++ b/backend/FertileNotify.Application/Services/ApiKeyService.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Services
+{
+    public class ApiKeyService
+    {
+        private readonly IApiKeyRepository _apiKeyRepository;
+
+        public ApiKeyService(IApiKeyRepository apiKeyRepository)
+        {
+            _apiKeyRepository = apiKeyRepository;
+        }
+
+        public async Task<string> CreateApiKeyAsync(Guid subscriberId, string name)
+        {
+            var randomBytes = new byte[32];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(randomBytes);
+            }
+            var key = "fn_" + Convert.ToBase64String(randomBytes).Replace("+", "").Replace("/", "").Substring(0, 30);
+
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(key));
+            var hash = Convert.ToBase64String(hashBytes);
+
+            var apiKey = new ApiKey(subscriberId, hash, key.Substring(0, 7), name);
+            await _apiKeyRepository.SaveAsync(apiKey);
+
+            return key;
+        }
+    }
+}

--- a/backend/FertileNotify.Domain/Entities/ApiKey.cs
+++ b/backend/FertileNotify.Domain/Entities/ApiKey.cs
@@ -1,0 +1,28 @@
+﻿namespace FertileNotify.Domain.Entities
+{
+    public class ApiKey
+    {
+        public Guid Id { get; private set; }
+        public Guid SubscriberId { get; private set; }
+        public string KeyHash { get; private set; } = string.Empty;
+        public string Prefix { get; private set; } = string.Empty;
+        public string Name { get; private set; } = string.Empty;
+        public bool IsActive { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+
+        private ApiKey() { }
+
+        public ApiKey(Guid subscriberId, string keyHash, string prefix, string name)
+        {
+            Id = Guid.NewGuid();
+            SubscriberId = subscriberId;
+            KeyHash = keyHash;
+            Prefix = prefix;
+            Name = name;
+            IsActive = true;
+            CreatedAt = DateTime.UtcNow;
+        }
+
+        public void Revoke() => IsActive = false;
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Migrations/20260204065844_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260204065844_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260131155210_InitialCreate")]
+    [Migration("20260204065844_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -24,6 +24,41 @@ namespace FertileNotify.Infrastructure.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            modelBuilder.Entity("FertileNotify.Domain.Entities.ApiKey", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("KeyHash")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("Prefix")
+                        .IsRequired()
+                        .HasMaxLength(9)
+                        .HasColumnType("character varying(9)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("ApiKeys");
+                });
 
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationTemplate", b =>
                 {

--- a/backend/FertileNotify.Infrastructure/Migrations/20260204065844_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260204065844_InitialCreate.cs
@@ -12,6 +12,23 @@ namespace FertileNotify.Infrastructure.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
+                name: "ApiKeys",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubscriberId = table.Column<Guid>(type: "uuid", nullable: false),
+                    KeyHash = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Prefix = table.Column<string>(type: "character varying(9)", maxLength: 9, nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeys", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "NotificationTemplates",
                 columns: table => new
                 {
@@ -62,6 +79,9 @@ namespace FertileNotify.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropTable(
+                name: "ApiKeys");
+
             migrationBuilder.DropTable(
                 name: "NotificationTemplates");
 

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -22,6 +22,41 @@ namespace FertileNotify.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("FertileNotify.Domain.Entities.ApiKey", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("KeyHash")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("Prefix")
+                        .IsRequired()
+                        .HasMaxLength(9)
+                        .HasColumnType("character varying(9)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("ApiKeys");
+                });
+
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationTemplate", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -10,6 +10,7 @@ namespace FertileNotify.Infrastructure.Persistence
 
         public DbSet<Subscriber> Subscribers { get; set; }
         public DbSet<Subscription> Subscriptions { get; set; }
+        public DbSet<ApiKey> ApiKeys { get; set; }
         public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/ApiKeyConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/ApiKeyConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using FertileNotify.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FertileNotify.Infrastructure.Persistence.Configurations
+{
+    public class ApiKeyConfiguration : IEntityTypeConfiguration<ApiKey>
+    {
+        public void Configure(EntityTypeBuilder<ApiKey> builder)
+        {
+            builder.HasKey(a => a.Id);
+
+            builder.Property(a => a.KeyHash)
+                .IsRequired()
+                .HasMaxLength(256);
+
+            builder.Property(a => a.Prefix)
+                .IsRequired()
+                .HasMaxLength(9);
+
+            builder.Property(a => a.Name)
+                .IsRequired()
+                .HasMaxLength(100);
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/EfApiKeyRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfApiKeyRepository.cs
@@ -1,0 +1,35 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class EfApiKeyRepository : IApiKeyRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public EfApiKeyRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public Task SaveAsync(ApiKey apiKey)
+        {
+            if (!_context.ApiKeys.Local.Any(k => k.Id == apiKey.Id || k.KeyHash == apiKey.KeyHash))
+            {
+                var exists = _context.ApiKeys.Any(k => k.Id == apiKey.Id);
+                if (!exists)
+                    _context.ApiKeys.Add(apiKey);
+                else
+                    _context.ApiKeys.Update(apiKey);
+            }
+            return _context.SaveChangesAsync();
+        }
+
+        public async Task<ApiKey?> GetByKeyHashAsync(string keyHash)
+            => await _context.ApiKeys.FirstOrDefaultAsync(k => k.KeyHash == keyHash);
+
+        public Task<List<ApiKey>> GetBySubscriberIdAsync(Guid subscriberId)
+            => _context.ApiKeys.Where(k => k.SubscriberId == subscriberId).OrderByDescending(k => k.CreatedAt).ToListAsync();
+    }
+}


### PR DESCRIPTION
Introduce API key support: add ApiKey domain entity, EF configuration, repository (IApiKeyRepository + EfApiKeyRepository) and migration to create the ApiKeys table. Add ApiKeyService to generate secure keys (store only hashed value + prefix) and validators/models for API key creation. Expose endpoints on SubscribersController to create, list and revoke API keys and return the raw key on creation. Implement ApiKeyAuthenticationHandler and register a combined auth scheme (JWT or API key) in Program.cs with DI registrations. Overall enables per-subscriber API keys with secure storage and management.