### PR TITLE
Add API key management to dashboard

### DIFF
--- a/frontend/src/api/subscriberService.ts
+++ b/frontend/src/api/subscriberService.ts
@@ -1,5 +1,5 @@
 import axiosClient  from "./axiosClient";
-import type { SubscriberProfile, UpdateCompanyName, UpdateContactInfo, UpdateChannel, UpdatePassword } from "../types/subscriber";
+import type { SubscriberProfile, UpdateCompanyName, UpdateContactInfo, UpdateChannel, UpdatePassword, CreateApiKey, ApiKeyResponse, ApiKey } from "../types/subscriber";
 
 export const subscriberService = {
     getProfile: async (): Promise<SubscriberProfile> => {
@@ -17,5 +17,16 @@ export const subscriberService = {
     },
     setPassword: async (data: UpdatePassword): Promise<void> => {
         await axiosClient.put("/subscribers/password", data);
+    },
+    setApikey: async (data: CreateApiKey): Promise<ApiKeyResponse> => {
+        const response = await axiosClient.post<ApiKeyResponse>("/subscribers/create-api-key", data);
+        return response.data;
+    },
+    getApiKeys: async (): Promise<ApiKey[]> => {
+        const response = await axiosClient.get<ApiKey[]>("/subscribers/api-keys");
+        return response.data;
+    },
+    deleteApiKey: async (key: string): Promise<void> => {
+        await axiosClient.delete(`/subscribers/api-keys/${key}`);
     }
 };

--- a/frontend/src/types/subscriber.ts
+++ b/frontend/src/types/subscriber.ts
@@ -32,3 +32,20 @@ export interface UpdatePassword {
     currentPassword: string;
     newPassword: string;
 }
+
+export interface CreateApiKey {
+    name: string;
+}
+
+export interface ApiKeyResponse {
+    apiKey: string;
+    message: string;
+}
+
+export interface ApiKey {
+    id: string;
+    prefix: string;
+    name: string;
+    isActive: boolean;
+    createdAt: string;
+}


### PR DESCRIPTION
Enable creating, listing and deleting subscriber API keys. Added types (CreateApiKey, ApiKeyResponse, ApiKey) and new service methods (setApikey, getApiKeys, deleteApiKey) in subscriberService. DashboardPage: add UI for API keys (card + creation input + list + delete), modal to show newly created key with copy behavior, state and helper functions (createApiKey, apiKeys, deleteApiKey, loadApiKeys, handleCopyApiKey, closeApiKeyModal), memoized fetchProfile/loadApiKeys effects, and minor UI/error message text tweaks. Files changed: frontend/src/api/subscriberService.ts, frontend/src/pages/DashboardPage.tsx, frontend/src/types/subscriber.ts.