### PR TITLE
Move DTOs to Application.DTOs and update controller

### DIFF
--- a/backend/FertileNotify.API/Controllers/SubscribersController.cs
+++ b/backend/FertileNotify.API/Controllers/SubscribersController.cs
@@ -1,6 +1,7 @@
 ﻿using FertileNotify.API.Models;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.Services;
+using FertileNotify.Application.DTOs;
 using FertileNotify.Application.UseCases.RegisterSubscriber;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Enums;

--- a/backend/FertileNotify.Application/DTOs/ApiKeyDto.cs
+++ b/backend/FertileNotify.Application/DTOs/ApiKeyDto.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.Application.DTOs
 {
     public class ApiKeyDto
     {

--- a/backend/FertileNotify.Application/DTOs/SubscriberDto.cs
+++ b/backend/FertileNotify.Application/DTOs/SubscriberDto.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.Application.DTOs
 {
     public class SubscriberDto
     {


### PR DESCRIPTION
Relocate ApiKeyDto and SubscriberDto from FertileNotify.API.Models to FertileNotify.Application.DTOs to centralize DTOs in the application layer. Update SubscribersController using directives to reference the new namespace. No functional changes intended — just a refactor to improve project structure and ownership of DTO types.