### PR TITLE
Trim email input and add domain unit tests

### DIFF
--- a/backend/FertileNotify.Domain/ValueObjects/EmailAddress.cs
+++ b/backend/FertileNotify.Domain/ValueObjects/EmailAddress.cs
@@ -13,6 +13,8 @@ namespace FertileNotify.Domain.ValueObjects
 
         public static EmailAddress Create(string email)
         {
+            email = email.Trim();
+
             if (string.IsNullOrWhiteSpace(email)) 
                 throw new ArgumentException("Email cannot be empty.");
 

--- a/backend/FertileNotify.Tests/EmailAddressTests.cs
+++ b/backend/FertileNotify.Tests/EmailAddressTests.cs
@@ -1,0 +1,28 @@
+﻿using FertileNotify.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace FertileNotify.Tests.Domain
+{
+    public class EmailAddressTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("test")]
+        [InlineData("test@")]
+        [InlineData("@test.com")]
+        [InlineData("test@test")]
+        public void Create_Should_ThrowException_When_Format_Is_Invalid(string invalidEmail)
+        {
+            var action = () => EmailAddress.Create(invalidEmail);
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void Create_Should_Trim_And_Lowercase_Email()
+        {
+            var email = EmailAddress.Create("  Test@Company.COM  ");
+
+            email.Value.Should().Be("test@company.com");
+        }
+    }
+}

--- a/backend/FertileNotify.Tests/PasswordTests.cs
+++ b/backend/FertileNotify.Tests/PasswordTests.cs
@@ -1,0 +1,46 @@
+﻿using FertileNotify.Domain.Exceptions;
+using FertileNotify.Domain.ValueObjects;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FertileNotify.Tests
+{
+    public class PasswordTests
+    {
+        [Theory]
+        [InlineData("123")]
+        [InlineData("abcdefgh")]
+        [InlineData("ABCDEFGH")]
+        [InlineData("Abcdefgh")]
+        public void Create_Should_ThrowException_When_Password_Is_Weak(string weakPassword)
+        {
+            var action = () => Password.Create(weakPassword);
+            action.Should().Throw<BusinessRuleException>();
+        }
+
+        [Fact]
+        public void Create_Should_Return_Password_When_Strong()
+        {
+            var password = Password.Create("StrongP@ss1");
+
+            password.Should().NotBeNull();
+            password.Hash.Should().NotBeNullOrEmpty();
+            password.Hash.Should().NotBe("StrongP@ss1");
+        }
+
+        [Fact]
+        public void Verify_Should_Return_True_For_Correct_Password()
+        {
+            var plain = "StrongP@ss1";
+            var password = Password.Create(plain);
+
+            var result = password.Verify(plain);
+
+            result.Should().BeTrue();
+        }
+    }
+}

--- a/backend/FertileNotify.Tests/SubscriberTests.cs
+++ b/backend/FertileNotify.Tests/SubscriberTests.cs
@@ -1,0 +1,59 @@
+﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.Exceptions;
+using FertileNotify.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace FertileNotify.Tests
+{
+    public class SubscriberTests
+    {
+        [Fact]
+        public void EnableChannel_Should_ThrowException_When_Plan_Does_Not_Support_Channel()
+        {
+            var subscriber = new Subscriber(
+                CompanyName.Create("Test LTC"),
+                Password.Create("StrongP@ssw0rd"),
+                EmailAddress.Create("test@test.com"),
+                PhoneNumber.Create("+123-456-78-90")
+            );
+
+            var plan = SubscriptionPlan.Free;
+
+            var action = () => subscriber.EnableChannel(NotificationChannel.SMS, plan);
+            action.Should().Throw<BusinessRuleException>().WithMessage("Your plan (Free) does not support the sms channel.");
+        }
+
+        [Fact]
+        public void EnableChannel_Should_Add_Channel_When_Plan_Supports_It()
+        {
+            var subscriber = new Subscriber(
+                CompanyName.Create("Test LTC"),
+                Password.Create("StrongP@ssw0rd"),
+                EmailAddress.Create("test@test.com"),
+                null
+            );
+
+            var plan = SubscriptionPlan.Free;
+
+            subscriber.EnableChannel(NotificationChannel.Console, plan);
+            subscriber.ActiveChannels.Should().Contain(NotificationChannel.Console);
+        }
+
+        [Fact]
+        public void EnableChannel_Should_ThrowException_When_SMS_Added_Without_PhoneNumber()
+        {
+            var subscriber = new Subscriber(
+                CompanyName.Create("Test LTC"),
+                Password.Create("StrongP@ssw0rd"),
+                EmailAddress.Create("test@test.com"),
+                null
+            );
+
+            var plan = SubscriptionPlan.Pro;
+
+            var action = () => subscriber.EnableChannel(NotificationChannel.SMS, plan);
+            action.Should().Throw<BusinessRuleException>().WithMessage("Phone number is required to enable SMS channel.");
+        }
+    }
+}


### PR DESCRIPTION
Ensure EmailAddress.Create trims incoming values and add comprehensive unit tests. This commit adds a trim in EmailAddress.Create and introduces new tests: EmailAddressTests (invalid formats and normalization), PasswordTests (strength validation, hashing and verification), and SubscriberTests (channel enablement rules and plan/phone validations) to cover core domain behaviors and business rules.