### PR TITLE
Add OTP-based two-step auth

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -1,7 +1,8 @@
+using FertileNotify.API.Models;
 using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
-using FertileNotify.API.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FertileNotify.API.Controllers
@@ -10,28 +11,50 @@ namespace FertileNotify.API.Controllers
     [Route("api/auth")]
     public class AuthController : ControllerBase
     {
-        private readonly ISubscriberRepository _userRepository;
+        private readonly ISubscriberRepository _subscriberRepository;
         private readonly ITokenService _tokenService;
+        private readonly IOtpService _otpService;
 
-        public AuthController(ISubscriberRepository userRepository, ITokenService tokenService)
+        public AuthController(
+            ISubscriberRepository subscriberRepository, 
+            ITokenService tokenService, 
+            IOtpService otpService)
         {
-            _userRepository = userRepository;
+            _subscriberRepository = subscriberRepository;
             _tokenService = tokenService;
+            _otpService = otpService;
         }
 
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
-            var user =
-                await _userRepository.GetByEmailAsync(EmailAddress.Create(request.Email))
-                ?? throw new NotFoundException("User not found");
+            var subscriber = await GetSubscriber(request.Email);
 
-            if (!user.Password.Verify(request.Password))
+            if (!subscriber.Password.Verify(request.Password))
                 throw new UnauthorizedException("Invalid credentials");
 
-            var token = _tokenService.GenerateToken(user);
+            var otpCode = await _otpService.GenerateOtpAsync(subscriber.Id);
 
+            return Ok(new { Message = "A special 6-character code valid for 5 minutes " +
+                                      "has been sent to your email address. Please enter this code." });
+        }
+
+        [HttpPost("verify-code")]
+        public async Task<IActionResult> VerifyCode([FromBody] OtpRequest request)
+        {
+            var subscriber = await GetSubscriber(request.Email);
+
+            var isValid = await _otpService.VerifyOtpAsync(subscriber.Id, request.OtpCode);
+
+            if (!isValid)
+                throw new UnauthorizedException("Invalid or expired OTP code");
+
+            var token = _tokenService.GenerateToken(subscriber);
             return Ok( new { Token = token } );
         }
+
+        public async Task<Subscriber> GetSubscriber(string email)
+            => await _subscriberRepository.GetByEmailAsync(EmailAddress.Create(email))
+                ?? throw new NotFoundException("Subscriber not found");
     }
 }

--- a/backend/FertileNotify.API/Models/OtpRequest.cs
+++ b/backend/FertileNotify.API/Models/OtpRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class OtpRequest
+    {
+        public string Email { get; set; } = string.Empty;
+        public string OtpCode { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -157,6 +157,9 @@ builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterSubscriberHandler>();
 builder.Services.AddScoped<TemplateEngine>();
 
+builder.Services.AddMemoryCache();
+builder.Services.AddScoped<IOtpService, OtpService>();
+
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.API/Validators/OtpRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/OtpRequestValidator.cs
@@ -1,0 +1,20 @@
+﻿using FertileNotify.API.Models;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class OtpRequestValidator : AbstractValidator<OtpRequest>
+    {
+        public OtpRequestValidator()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("Email is required.")
+                .EmailAddress().WithMessage("Invalid email format.");
+
+            RuleFor(x => x.OtpCode)
+                .NotEmpty().WithMessage("OTP code is required.")
+                .Length(6).WithMessage("OTP code must be 6 characters long.")
+                .Must(code => code.All(char.IsDigit)).WithMessage("OTP code must contain only digits.");
+        }
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/IOtpService.cs
+++ b/backend/FertileNotify.Application/Interfaces/IOtpService.cs
@@ -1,0 +1,8 @@
+﻿namespace FertileNotify.Application.Interfaces
+{
+    public interface IOtpService
+    {
+        Task<string> GenerateOtpAsync(Guid subscriberId);
+        Task<bool> VerifyOtpAsync(Guid subscriberId, string otp);
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Authentication/OtpService.cs
+++ b/backend/FertileNotify.Infrastructure/Authentication/OtpService.cs
@@ -1,0 +1,42 @@
+﻿using FertileNotify.Application.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FertileNotify.Infrastructure.Authentication
+{
+    public class OtpService : IOtpService
+    {
+        private readonly IMemoryCache _cache;
+
+        public OtpService(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public Task<string> GenerateOtpAsync(Guid subscriberId)
+        {
+            var otp = new Random().Next(100000, 999999).ToString();
+            var key = $"otp_{subscriberId}";
+
+            var cacheEntryOptions = new MemoryCacheEntryOptions()
+                .SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+
+            _cache.Set(key, otp, cacheEntryOptions);
+            Console.WriteLine($"Generated OTP for subscriber {subscriberId}: {otp}"); // For development purposes only
+            return Task.FromResult(otp);
+        }
+
+        public Task<bool> VerifyOtpAsync(Guid subscriberId, string otp)
+        {
+            var key = $"otp_{subscriberId}";
+            if (_cache.TryGetValue(key, out string? cachedOtp))
+            {
+                if (cachedOtp == otp)
+                {
+                    _cache.Remove(key);
+                    return Task.FromResult(true);
+                }
+            }
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -19,13 +19,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Authentication\" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Introduce a two-step OTP login flow: on login an OTP is generated and sent (dev-logged) and a new verify-code endpoint validates the OTP before issuing the token. Added OtpRequest model and OtpRequestValidator (FluentValidation). Defined IOtpService interface and provided OtpService implementation using IMemoryCache (registered in DI and AddMemoryCache in Program). Updated AuthController to use Subscriber naming, generate OTP on login, verify OTP, and added a GetSubscriber helper. Also added Microsoft.Extensions.Caching.Memory to the infrastructure csproj.