### PR TITLE
Support subscription plan in auth and rate limiting

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -12,15 +12,18 @@ namespace FertileNotify.API.Controllers
     public class AuthController : ControllerBase
     {
         private readonly ISubscriberRepository _subscriberRepository;
+        private readonly ISubscriptionRepository _subscriptionRepository;
         private readonly ITokenService _tokenService;
         private readonly IOtpService _otpService;
 
         public AuthController(
-            ISubscriberRepository subscriberRepository, 
+            ISubscriberRepository subscriberRepository,
+            ISubscriptionRepository subscriptionRepository,
             ITokenService tokenService, 
             IOtpService otpService)
         {
             _subscriberRepository = subscriberRepository;
+            _subscriptionRepository = subscriptionRepository;
             _tokenService = tokenService;
             _otpService = otpService;
         }
@@ -49,7 +52,10 @@ namespace FertileNotify.API.Controllers
             if (!isValid)
                 throw new UnauthorizedException("Invalid or expired OTP code");
 
-            var token = _tokenService.GenerateToken(subscriber);
+            var subscription = await _subscriptionRepository.GetBySubscriberIdAsync(subscriber.Id)
+                                ?? throw new NotFoundException("Subscription not found");
+
+            var token = _tokenService.GenerateToken(subscriber, subscription.Plan);
             return Ok( new { Token = token } );
         }
 

--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -6,12 +6,10 @@ using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 
 namespace FertileNotify.API.Controllers
 {
-    [EnableRateLimiting("fixed")]
     [Authorize]
     [ApiController]
     [Route("api/notifications")]

--- a/backend/FertileNotify.Application/Interfaces/ITokenService.cs
+++ b/backend/FertileNotify.Application/Interfaces/ITokenService.cs
@@ -1,9 +1,10 @@
 using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
 
 namespace FertileNotify.Application.Interfaces
 {
     public interface ITokenService
     {
-        string GenerateToken(Subscriber user);
+        string GenerateToken(Subscriber user, SubscriptionPlan plan);
     }
 }

--- a/backend/FertileNotify.Infrastructure/Authentication/JwtTokenService.cs
+++ b/backend/FertileNotify.Infrastructure/Authentication/JwtTokenService.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Text;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Enums;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
@@ -17,7 +18,7 @@ namespace FertileNotify.Infrastructure.Authentication
             _configuration = configuration;
         }
 
-        public string GenerateToken(Subscriber user)
+        public string GenerateToken(Subscriber user, SubscriptionPlan plan)
         {
             var jwtSettings = _configuration.GetSection("JwtSettings");
             var secretKey = Encoding.UTF8.GetBytes(jwtSettings["SecretKey"]!);
@@ -26,6 +27,7 @@ namespace FertileNotify.Infrastructure.Authentication
             {
                 new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
                 new Claim(JwtRegisteredClaimNames.Email, user.Email.Value),
+                new Claim("plan", plan.ToString()),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
             };
 


### PR DESCRIPTION
Inject subscription data into authentication flow and include subscription plan in user claims and JWTs, enabling plan-based rate limiting. Changes:

- ApiKeyAuthenticationHandler: added ISubscriptionRepository, fetches subscriber's subscription and adds a "Plan" claim to the principal.
- AuthController: fetches subscription for authenticated subscriber and passes SubscriptionPlan to ITokenService when generating tokens.
- ITokenService: method signature updated to GenerateToken(Subscriber, SubscriptionPlan).
- JwtTokenService: updated to accept SubscriptionPlan and add a "plan" claim to JWT payload.
- Rate limiting (Program.cs): replaced fixed window limiter with a PartitionedRateLimiter that partitions by subscriber (or IP/anonymous) and uses the user's plan to set permit limits (Free=5, Pro=20, Enterprise=100 per minute). QueueLimit set to 0 and OnRejected now returns a 429 with a friendly message. Also changed API key header detection to "FN-Api-Key".
- NotificationsController: removed per-controller EnableRateLimiting attribute (global limiter now handles limits).

These changes enable per-subscription plan throttling and propagate plan info through claims and tokens so authorization and middleware can make rate decisions.