### PR TITLE
Add refresh token support and refresh endpoint

### DIFF
--- a/backend/FertileNotify.API/Models/RefreshTokenRequest.cs
+++ b/backend/FertileNotify.API/Models/RefreshTokenRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class RefreshTokenRequest()
+    {
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Validators/RefreshTokenRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/RefreshTokenRequestValidator.cs
@@ -1,0 +1,15 @@
+﻿using FertileNotify.API.Models;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class RefreshTokenRequestValidator : AbstractValidator<RefreshTokenRequest>
+    {
+        public RefreshTokenRequestValidator()
+        {
+            RuleFor(x => x.RefreshToken)
+                .NotEmpty().WithMessage("Refresh token is required.")
+                .MinimumLength(20).WithMessage("Refresh token must be at least 20 characters long.");
+        }
+    }
+}

--- a/backend/FertileNotify.API/appsettings.json
+++ b/backend/FertileNotify.API/appsettings.json
@@ -16,7 +16,7 @@
     "SecretKey": "YourSuperSecretKeyHere",
     "Issuer": "FertileNotifyAPI",
     "Audience": "FertileNotifyClients",
-    "ExpiryInMinutes": 60
+    "ExpiryInMinutes": 15
   },
 
   "ConnectionStrings": {

--- a/backend/FertileNotify.Application/Interfaces/ISubscriberRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/ISubscriberRepository.cs
@@ -9,6 +9,8 @@ namespace FertileNotify.Application.Interfaces
         Task<Subscriber?> GetByIdAsync(Guid id);
         Task<List<Guid>> GetExistingIdsAsync(List<Guid> ids);
         Task<Subscriber?> GetByEmailAsync(EmailAddress email);
+        Task<Subscriber?> GetByPhoneNumberAsync(PhoneNumber phoneNumber);
+        Task<Subscriber?> GetByRefreshTokenAsync(string refreshToken);
         Task<bool> ExistsAsync(Guid id);
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/ITokenService.cs
+++ b/backend/FertileNotify.Application/Interfaces/ITokenService.cs
@@ -1,10 +1,12 @@
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.ValueObjects;
 
 namespace FertileNotify.Application.Interfaces
 {
     public interface ITokenService
     {
         string GenerateToken(Subscriber user, SubscriptionPlan plan);
+        RefreshToken GenerateRefreshToken();
     }
 }

--- a/backend/FertileNotify.Domain/Entities/Subscriber.cs
+++ b/backend/FertileNotify.Domain/Entities/Subscriber.cs
@@ -2,7 +2,6 @@ using FertileNotify.Domain.Enums;
 using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.Rules;
 using FertileNotify.Domain.ValueObjects;
-using System.Numerics;
 
 namespace FertileNotify.Domain.Entities
 {
@@ -13,6 +12,7 @@ namespace FertileNotify.Domain.Entities
         public Password Password { get; private set; }
         public EmailAddress Email { get; private set; }
         public PhoneNumber? PhoneNumber { get; private set; }
+        public RefreshToken? RefreshToken { get; private set; }
 
         private readonly HashSet<NotificationChannel> _activeChannels = new();
         public IReadOnlyCollection<NotificationChannel> ActiveChannels => _activeChannels;
@@ -43,6 +43,8 @@ namespace FertileNotify.Domain.Entities
         public void UpdateCompanyName(CompanyName companyName) => CompanyName = companyName;
 
         public void UpdatePassword(Password password) => Password = password;
+
+        public void SetRefreshToken(RefreshToken refreshToken) => RefreshToken = refreshToken;
 
         public void UpdateContactInfo(EmailAddress email, PhoneNumber? phoneNumber)
         {

--- a/backend/FertileNotify.Domain/ValueObjects/RefreshToken.cs
+++ b/backend/FertileNotify.Domain/ValueObjects/RefreshToken.cs
@@ -1,0 +1,27 @@
+﻿namespace FertileNotify.Domain.ValueObjects
+{
+    public sealed class RefreshToken
+    {
+        public string Token { get; private set; }
+        public DateTime ExpiresAt { get; private set; }
+        public bool IsRevoked { get; private set; }
+
+        private RefreshToken() 
+        {
+            Token = string.Empty;
+            ExpiresAt = DateTime.UtcNow;
+            IsRevoked = false;
+        }
+
+        public RefreshToken(string token, DateTime expires)
+        {
+            Token = token;
+            ExpiresAt = expires;
+            IsRevoked = false;
+        }
+
+        public bool IsActive() => !IsRevoked && DateTime.UtcNow < ExpiresAt;
+
+        public void Revoke() => IsRevoked = true;
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Authentication/JwtTokenService.cs
+++ b/backend/FertileNotify.Infrastructure/Authentication/JwtTokenService.cs
@@ -1,9 +1,11 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
@@ -45,6 +47,17 @@ namespace FertileNotify.Infrastructure.Authentication
             var token = tokenHandler.CreateToken(tokenDescriptor);
 
             return tokenHandler.WriteToken(token);
+        }
+
+        public RefreshToken GenerateRefreshToken()
+        {
+            var randomBytes = new byte[32];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
+
+            var token = Convert.ToBase64String(randomBytes);
+
+            return new RefreshToken(token, DateTime.UtcNow.AddDays(7));
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Migrations/20260207072300_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260207072300_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260204065844_InitialCreate")]
+    [Migration("20260207072300_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -147,6 +147,38 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Subscriptions");
+                });
+
+            modelBuilder.Entity("FertileNotify.Domain.Entities.Subscriber", b =>
+                {
+                    b.OwnsOne("FertileNotify.Domain.ValueObjects.RefreshToken", "RefreshToken", b1 =>
+                        {
+                            b1.Property<Guid>("SubscriberId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<DateTime>("ExpiresAt")
+                                .HasColumnType("timestamp with time zone")
+                                .HasColumnName("RefreshTokenExpiresAt");
+
+                            b1.Property<bool>("IsRevoked")
+                                .HasColumnType("boolean")
+                                .HasColumnName("RefreshTokenRevoked");
+
+                            b1.Property<string>("Token")
+                                .IsRequired()
+                                .HasMaxLength(256)
+                                .HasColumnType("character varying(256)")
+                                .HasColumnName("RefreshToken");
+
+                            b1.HasKey("SubscriberId");
+
+                            b1.ToTable("Subscribers");
+
+                            b1.WithOwner()
+                                .HasForeignKey("SubscriberId");
+                        });
+
+                    b.Navigation("RefreshToken");
                 });
 #pragma warning restore 612, 618
         }

--- a/backend/FertileNotify.Infrastructure/Migrations/20260207072300_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260207072300_InitialCreate.cs
@@ -51,6 +51,9 @@ namespace FertileNotify.Infrastructure.Migrations
                     Password = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
                     Email = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
                     PhoneNumber = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    RefreshToken = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    RefreshTokenExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RefreshTokenRevoked = table.Column<bool>(type: "boolean", nullable: true),
                     ActiveChannels = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -145,6 +145,38 @@ namespace FertileNotify.Infrastructure.Migrations
 
                     b.ToTable("Subscriptions");
                 });
+
+            modelBuilder.Entity("FertileNotify.Domain.Entities.Subscriber", b =>
+                {
+                    b.OwnsOne("FertileNotify.Domain.ValueObjects.RefreshToken", "RefreshToken", b1 =>
+                        {
+                            b1.Property<Guid>("SubscriberId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<DateTime>("ExpiresAt")
+                                .HasColumnType("timestamp with time zone")
+                                .HasColumnName("RefreshTokenExpiresAt");
+
+                            b1.Property<bool>("IsRevoked")
+                                .HasColumnType("boolean")
+                                .HasColumnName("RefreshTokenRevoked");
+
+                            b1.Property<string>("Token")
+                                .IsRequired()
+                                .HasMaxLength(256)
+                                .HasColumnType("character varying(256)")
+                                .HasColumnName("RefreshToken");
+
+                            b1.HasKey("SubscriberId");
+
+                            b1.ToTable("Subscribers");
+
+                            b1.WithOwner()
+                                .HasForeignKey("SubscriberId");
+                        });
+
+                    b.Navigation("RefreshToken");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/SubscriberConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/SubscriberConfiguration.cs
@@ -43,6 +43,17 @@ namespace FertileNotify.Infrastructure.Persistence.Configurations
                 )
                 .HasMaxLength(20);
 
+            builder.OwnsOne(u => u.RefreshToken, rt =>
+            {
+                rt.Property(r => r.Token)
+                    .HasColumnName("RefreshToken")
+                    .HasMaxLength(256);
+                rt.Property(r => r.ExpiresAt)
+                    .HasColumnName("RefreshTokenExpiresAt");
+                rt.Property(r => r.IsRevoked)
+                    .HasColumnName("RefreshTokenRevoked");
+            });
+
             builder.Property(u => u.ActiveChannels)
                 .HasConversion(
                     v => string.Join(',', v.Select(c => c.Name)),

--- a/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberRepository.cs
@@ -37,6 +37,12 @@ namespace FertileNotify.Infrastructure.Persistence
         public async Task<Subscriber?> GetByEmailAsync(EmailAddress email)
             => await _context.Subscribers.FirstOrDefaultAsync(u => u.Email == email);
 
+        public async Task<Subscriber?> GetByPhoneNumberAsync(PhoneNumber phoneNumber)
+            => await _context.Subscribers.FirstOrDefaultAsync(u => u.PhoneNumber == phoneNumber);
+
+        public async Task<Subscriber?> GetByRefreshTokenAsync(string refreshToken)
+            => await _context.Subscribers.FirstOrDefaultAsync(u => u.RefreshToken!.Token == refreshToken);
+
         public async Task<bool> ExistsAsync(Guid id)
             => await _context.Subscribers.AnyAsync(u => u.Id == id);
     }


### PR DESCRIPTION
Introduce a refresh token flow so clients can obtain new access tokens without re-authenticating. Adds a RefreshToken value object, a GenerateRefreshToken method in JwtTokenService, subscriber RefreshToken property and SetRefreshToken, and returns AccessToken + RefreshToken on login. Adds POST /refresh-token endpoint with RefreshTokenRequest model and FluentValidation validator that validates incoming refresh tokens. Persistence updated: repository method GetByRefreshTokenAsync, EF configuration to own RefreshToken fields, and migration/snapshot updated to include RefreshToken, RefreshTokenExpiresAt and RefreshTokenRevoked columns. Also adds GetByPhoneNumberAsync and reduces JWT expiry in appsettings from 60 to 15 minutes.