### PR TITLE
Add OTP login flow and token refresh

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -55,10 +55,10 @@ builder.Services.AddRateLimiter(options =>
 
         int permitLimit = plan switch
         {
-            "Free" => 5,
-            "Pro" => 20,
-            "Enterprise" => 100,
-            _ => 5
+            "Free" => 50,
+            "Pro" => 100,
+            "Enterprise" => 1000,
+            _ => 20
         };
 
         return RateLimitPartition.GetFixedWindowLimiter(
@@ -198,11 +198,11 @@ if (app.Environment.IsDevelopment())
 // --- 8. Database Seed ---
 await DbSeeder.SeedAsync(app);
 
+app.UseCors("AllowAll");
+
 app.UseRateLimiter();
 
 app.UseMiddleware<ExceptionHandlingMiddleware>();
-
-app.UseCors("AllowAll");
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/frontend/src/api/authService.ts
+++ b/frontend/src/api/authService.ts
@@ -1,9 +1,13 @@
 import axiosClient from "./axiosClient";
-import type { LoginRequest, LoginResponse, RegisterRequest } from "../types/auth";
+import type { LoginRequest, LoginResponse, RegisterRequest, VerifyOtpRequest, VerifyOtpResponse } from "../types/auth";
 
 export const authService = {
     login: async (data: LoginRequest): Promise<LoginResponse> => {
         const response = await axiosClient.post<LoginResponse>("/auth/login", data);
+        return response.data;
+    },
+    verifyOtp: async (data: VerifyOtpRequest): Promise<VerifyOtpResponse> => {
+        const response = await axiosClient.post<VerifyOtpResponse>("/auth/verify-code", data);
         return response.data;
     },
     register: async (data: RegisterRequest): Promise<void> => {

--- a/frontend/src/api/axiosClient.ts
+++ b/frontend/src/api/axiosClient.ts
@@ -8,11 +8,46 @@ const axiosClient = axios.create({
 });
 
 axiosClient.interceptors.request.use(config => {
-    const token = localStorage.getItem("token");
+    const token = localStorage.getItem("accessToken");
     if (token) {
         config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
 });
+
+axiosClient.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            originalRequest._retry = true;
+
+            try {
+                const refreshToken = localStorage.getItem("refreshToken");
+                if (!refreshToken) {
+                    throw new Error("No refresh token available");
+                }
+                const response = await axios.post("http://localhost:5082/api/auth/refresh-token", {
+                    token: refreshToken
+                });
+                const { accessToken, refreshToken: newRefreshToken } = response.data;
+                localStorage.setItem("accessToken", accessToken);
+                localStorage.setItem("refreshToken", newRefreshToken.token);
+
+                originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+                return axiosClient(originalRequest);
+            } catch (err) {
+                console.error('Session expired:', err);
+
+                localStorage.removeItem('accessToken');
+                localStorage.removeItem('refreshToken');
+                window.location.href = '/login';
+
+                return Promise.reject(err);
+            }
+        }
+        return Promise.reject(error);
+    }
+);
 
 export default axiosClient;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,89 +1,206 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { authService } from "../api/authService";
 
 export default function LoginPage() {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [otpCode, setOtpCode] = useState("");
     const [error, setError] = useState<string | null>(null);
+    const [showOtpForm, setShowOtpForm] = useState(false);
+    const [timeLeft, setTimeLeft] = useState(300);
     const navigate = useNavigate();
+
+    useEffect(() => {
+        if (showOtpForm && timeLeft > 0) {
+            const timer = setInterval(() => {
+                setTimeLeft((prev) => {
+                    if (prev <= 1) {
+                        setError("OTP code has expired. Please login again.");
+                        return 0;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+            return () => clearInterval(timer);
+        }
+    }, [showOtpForm, timeLeft]);
+
+    const formatTime = (seconds: number) => {
+        const mins = Math.floor(seconds / 60);
+        const secs = seconds % 60;
+        return `${mins}:${secs.toString().padStart(2, '0')}`;
+    };
 
     const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
+        setError(null);
         try {
-            const response = await authService.login({ email, password });
-            localStorage.setItem("token", response.token);
-            navigate("/dashboard");
+            await authService.login({ email, password });
+            setShowOtpForm(true);
+            setTimeLeft(300);
         } catch (err) {
             setError("Invalid email or password");
             console.error("Login error:", err);
         }
     };
 
+    const handleVerifyOtp = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+        
+        if (timeLeft === 0) {
+            setError("OTP code has expired. Please login again.");
+            return;
+        }
+
+        try {
+            const response = await authService.verifyOtp({ email, otpCode });
+            localStorage.setItem("accessToken", response.accessToken);
+            localStorage.setItem("refreshToken", response.refreshToken.token);
+            navigate("/dashboard");
+        } catch (err) {
+            setError("Invalid OTP code");
+            console.error("OTP verification error:", err);
+        }
+    };
+
     return (
         <div className="min-h-screen bg-animated-gradient flex items-center justify-center px-4 animate-fade-in">
-            <div className="glass p-8 md:p-10 w-full max-w-md animate-slide-up clip-sharp border-t-4 border-purple-500">
-                {/* Logo/Title */}
-                <div className="text-center mb-8">
-                    <h2 className="text-4xl font-display font-bold gradient-text mb-2 uppercase tracking-wider">Login</h2>
-                    <div className="h-1 w-20 bg-gradient-to-r from-purple-500 to-pink-500 mx-auto mb-3"></div>
-                    <p className="text-gray-400 uppercase text-sm tracking-wide">Access Your Account</p>
-                </div>
-
-                {/* Error Message */}
-                {error && (
-                    <div className="bg-red-900/30 border-l-4 border-red-500 text-red-300 p-4 mb-6 clip-sharp-sm animate-slide-up">
-                        <p className="font-medium uppercase text-sm">{error}</p>
-                    </div>
-                )}
-
-                {/* Login Form */}
-                <form onSubmit={handleLogin} className="space-y-5">
-                    <div>
-                        <label className="block text-purple-300 font-semibold mb-2 uppercase text-sm tracking-wide">Company Email</label>
-                        <input
-                            type="email"
-                            className="input-modern"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="company@example.com"
-                            required
-                        />
+            {!showOtpForm ? (
+                // Login Form
+                <div className="glass p-8 md:p-10 w-full max-w-md animate-slide-up clip-sharp border-t-4 border-purple-500">
+                    {/* Logo/Title */}
+                    <div className="text-center mb-8">
+                        <h2 className="text-4xl font-display font-bold gradient-text mb-2 uppercase tracking-wider">Login</h2>
+                        <div className="h-1 w-20 bg-gradient-to-r from-purple-500 to-pink-500 mx-auto mb-3"></div>
+                        <p className="text-gray-400 uppercase text-sm tracking-wide">Access Your Account</p>
                     </div>
 
-                    <div>
-                        <label className="block text-purple-300 font-semibold mb-2 uppercase text-sm tracking-wide">Password</label>
-                        <input
-                            type="password"
-                            className="input-modern"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="••••••••"
-                            required
-                        />
-                    </div>
+                    {/* Error Message */}
+                    {error && (
+                        <div className="bg-red-900/30 border-l-4 border-red-500 text-red-300 p-4 mb-6 clip-sharp-sm animate-slide-up">
+                            <p className="font-medium uppercase text-sm">{error}</p>
+                        </div>
+                    )}
 
-                    <button
-                        type="submit"
-                        className="btn-gradient w-full text-lg uppercase tracking-wider mt-6"
-                    >
-                        Login
-                    </button>
-                </form>
+                    {/* Login Form */}
+                    <form onSubmit={handleLogin} className="space-y-5">
+                        <div>
+                            <label className="block text-purple-300 font-semibold mb-2 uppercase text-sm tracking-wide">Company Email</label>
+                            <input
+                                type="email"
+                                className="input-modern"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                placeholder="company@example.com"
+                                required
+                            />
+                        </div>
 
-                {/* Register Link */}
-                <div className="mt-6 text-center">
-                    <p className="text-gray-400">
-                        Don't have an account?{" "}
+                        <div>
+                            <label className="block text-purple-300 font-semibold mb-2 uppercase text-sm tracking-wide">Password</label>
+                            <input
+                                type="password"
+                                className="input-modern"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                placeholder="••••••••"
+                                required
+                            />
+                        </div>
+
                         <button
-                            onClick={() => navigate("/register")}
+                            type="submit"
+                            className="btn-gradient w-full text-lg uppercase tracking-wider mt-6"
+                        >
+                            Login
+                        </button>
+                    </form>
+
+                    {/* Register Link */}
+                    <div className="mt-6 text-center">
+                        <p className="text-gray-400">
+                            Don't have an account?{" "}
+                            <button
+                                onClick={() => navigate("/register")}
+                                className="text-purple-400 font-semibold hover:text-pink-400 transition-colors uppercase text-sm"
+                            >
+                                Sign Up
+                            </button>
+                        </p>
+                    </div>
+                </div>
+            ) : (
+                // OTP Verify Form
+                <div className="glass p-8 md:p-10 w-full max-w-md animate-slide-up clip-sharp border-t-4 border-purple-500">
+                    <div className="text-center mb-8">
+                        <h2 className="text-4xl font-display font-bold gradient-text mb-2 uppercase tracking-wider">Verify OTP</h2>
+                        <div className="h-1 w-20 bg-gradient-to-r from-purple-500 to-pink-500 mx-auto mb-3"></div>
+                        <p className="text-gray-400 uppercase text-sm tracking-wide">Enter the OTP sent to your email</p>
+                    </div>
+
+                    {/* Timer Display */}
+                    <div className="mb-6 text-center">
+                        <div className={`inline-block px-6 py-3 rounded-lg ${
+                            timeLeft > 60 ? 'bg-green-900/30 border border-green-500' : 'bg-red-900/30 border border-red-500'
+                        }`}>
+                            <p className="text-sm text-gray-400 mb-1">Code expires in</p>
+                            <p className={`text-3xl font-bold font-mono ${
+                                timeLeft > 60 ? 'text-green-400' : 'text-red-400'
+                            }`}>
+                                {formatTime(timeLeft)}
+                            </p>
+                        </div>
+                    </div>
+
+                    {/* Error Message */}
+                    {error && (
+                        <div className="bg-red-900/30 border-l-4 border-red-500 text-red-300 p-4 mb-6 clip-sharp-sm animate-slide-up">
+                            <p className="font-medium uppercase text-sm">{error}</p>
+                        </div>
+                    )}
+
+                    <form onSubmit={handleVerifyOtp} className="space-y-5">
+                        <div>
+                            <label className="block text-purple-300 font-semibold mb-2 uppercase text-sm tracking-wide">OTP Code</label>
+                            <input
+                                type="text"
+                                className="input-modern text-center text-2xl tracking-widest"
+                                value={otpCode}
+                                onChange={(e) => setOtpCode(e.target.value)}
+                                placeholder="000000"
+                                required
+                                maxLength={6}
+                                disabled={timeLeft === 0}
+                            />
+                        </div>
+
+                        <button
+                            type="submit"
+                            className="btn-gradient w-full text-lg uppercase tracking-wider mt-6"
+                            disabled={timeLeft === 0}
+                        >
+                            Verify OTP
+                        </button>
+                    </form>
+
+                    {/* Back to Login */}
+                    <div className="mt-6 text-center">
+                        <button
+                            onClick={() => {
+                                setShowOtpForm(false);
+                                setError(null);
+                                setOtpCode("");
+                                setTimeLeft(300);
+                            }}
                             className="text-purple-400 font-semibold hover:text-pink-400 transition-colors uppercase text-sm"
                         >
-                            Sign Up
+                            Back to Login
                         </button>
-                    </p>
+                    </div>
                 </div>
-            </div>
+            )}
         </div>
     );
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -4,7 +4,22 @@ export interface LoginRequest {
 }
 
 export interface LoginResponse {
-    token: string;
+    message: string;
+}
+
+export interface VerifyOtpRequest {
+    email: string;
+    otpCode: string;
+}
+
+export interface VerifyOtpResponse {
+    accessToken: string;
+    refreshToken:
+    {
+        token: string,
+        expiresAt: string,
+        isRevoked: boolean
+    };
 }
 
 export interface RegisterRequest {


### PR DESCRIPTION
Introduce a multi-step OTP login flow and automatic token refresh. Frontend: add VerifyOtp types and authService.verifyOtp, update LoginPage to show OTP form with a 5-minute countdown, verify OTP to store accessToken/refreshToken, and change localStorage key usage from "token" to "accessToken". axiosClient: add response interceptor to attempt refresh-token POST on 401, update stored tokens, retry original request, and redirect to /login on failure. Backend: increase rate limits for Free/Pro/Enterprise tiers and move UseCors("AllowAll") earlier in the middleware pipeline (removed duplicate).