### PR TITLE
Support per-subscriber templates and expand events

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -85,6 +85,7 @@ namespace FertileNotify.API.Controllers
             return Ok(new { AccessToken = newAccessToken, RefreshToken = newRefreshToken });
         }
 
+        [NonAction]
         public async Task<Subscriber> GetSubscriber(string email)
             => await _subscriberRepository.GetByEmailAsync(EmailAddress.Create(email))
                 ?? throw new NotFoundException("Subscriber not found");

--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -65,6 +65,7 @@ namespace FertileNotify.API.Controllers
             });
         }
 
+        [NonAction]
         private Guid GetSubscriberIdFromClaims()
         {
             var subscriberIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)

--- a/backend/FertileNotify.API/Controllers/SubscribersController.cs
+++ b/backend/FertileNotify.API/Controllers/SubscribersController.cs
@@ -179,6 +179,7 @@ namespace FertileNotify.API.Controllers
             return Ok();
         }
 
+        [NonAction]
         private Guid GetSubscriberIdFromClaims()
         {
             var subscriberIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)
@@ -186,6 +187,7 @@ namespace FertileNotify.API.Controllers
             return Guid.Parse(subscriberIdClaim.Value);
         }
 
+        [NonAction]
         private async Task<Subscriber> GetSubscriberAsync()
             => await _subscriberRepository.GetByIdAsync(GetSubscriberIdFromClaims())
                 ?? throw new NotFoundException("Subscriber not found.");

--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -1,0 +1,55 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using FertileNotify.API.Models;
+
+namespace FertileNotify.API.Controllers
+{
+    [ApiController]
+    [Route("api/templates")]
+    [Authorize]
+    public class TemplatesController : ControllerBase
+    {
+        private readonly ITemplateRepository _templateRepository;
+        private readonly ISubscriberRepository _subscriberRepository;
+
+        public TemplatesController(ITemplateRepository templateRepository, ISubscriberRepository subscriberRepository)
+        {
+            _templateRepository = templateRepository;
+            _subscriberRepository = subscriberRepository;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateOrUpdate([FromBody] CreateTemplateRequest request)
+        {
+            var subscriberId = GetSubscriberIdFromClaims();
+            var eventType = EventType.From(request.EventType);
+
+            var existingTemplate = await _templateRepository.GetTemplateAsync(eventType, subscriberId);
+
+            if (existingTemplate != null)
+            {
+                existingTemplate.Update(request.SubjectTemplate, request.BodyTemplate);
+            }
+            else
+            {
+                var newTemplate = NotificationTemplate.CreateCustom(subscriberId, eventType, request.SubjectTemplate, request.BodyTemplate);
+                await _templateRepository.AddAsync(newTemplate);
+            }
+
+            return Ok();
+        }
+
+        [NonAction]
+        private Guid GetSubscriberIdFromClaims()
+        {
+            var subscriberIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)
+                ?? throw new UnauthorizedException("Subscriber ID claim not found.");
+            return Guid.Parse(subscriberIdClaim.Value);
+        }
+    }
+}

--- a/backend/FertileNotify.API/Models/CreateTemplateRequest.cs
+++ b/backend/FertileNotify.API/Models/CreateTemplateRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class CreateTemplateRequest
+    {
+        public string EventType { get; set; } = null!;
+        public string SubjectTemplate { get; set; } = null!;
+        public string BodyTemplate { get; set; } = null!;
+    }
+}

--- a/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
@@ -1,0 +1,34 @@
+﻿using FertileNotify.API.Models;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class CreateTemplateRequestValidator : AbstractValidator<CreateTemplateRequest>
+    {
+        public CreateTemplateRequestValidator()
+        {
+            RuleFor(x => x.EventType)
+                .NotEmpty().WithMessage("EventType is required.")
+                .Must(BeAValidEventType).WithMessage("Invalid EventType.");
+
+            RuleFor(x => x.SubjectTemplate)
+                .NotEmpty().WithMessage("SubjectTemplate is required.");
+
+            RuleFor(x => x.BodyTemplate)
+                .NotEmpty().WithMessage("BodyTemplate is required.");
+        }
+
+        private bool BeAValidEventType(string eventType)
+        {
+            try
+            {
+                Domain.Events.EventType.From(eventType);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
@@ -5,7 +5,9 @@ namespace FertileNotify.Application.Interfaces
 {
     public interface ITemplateRepository
     {
-        Task<NotificationTemplate?> GetByEventTypeAsync(EventType eventType);
+        Task<NotificationTemplate?> GetTemplateAsync(EventType eventType, Guid? subscriberId);
+        Task<NotificationTemplate?> GetGlobalTemplateAsync(EventType eventType);
+        Task<NotificationTemplate?> GetCustomTemplateAsync(EventType eventType, Guid subscriberId);
         Task AddAsync(NotificationTemplate template);
     }
 }

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -54,7 +54,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
 
             subscription.EnsureCanSendNotification();
 
-            var template = await _templateRepository.GetByEventTypeAsync(command.EventType)
+            var template = await _templateRepository.GetTemplateAsync(command.EventType, command.SubscriberId)
                 ?? throw new NotFoundException("Notification template not found");
 
             string subject = command.EventType.Name;

--- a/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
@@ -5,21 +5,23 @@ namespace FertileNotify.Domain.Entities
     public class NotificationTemplate
     {
         public Guid Id { get; private set; }
+        public Guid? SubscriberId { get; private set; }
         public EventType EventType { get; private set; } = default!;
         public string SubjectTemplate { get; private set; } = string.Empty;
         public string BodyTemplate { get; private set; } = string.Empty;
 
         private NotificationTemplate() { }
 
-        private NotificationTemplate(EventType eventType, string subject, string body) 
+        private NotificationTemplate(EventType eventType, string subject, string body, Guid? subscriberId = null)
         {
             Id = Guid.NewGuid();
+            SubscriberId = subscriberId;
             EventType = eventType;
             SubjectTemplate = subject;
             BodyTemplate = body;
         }
 
-        public static NotificationTemplate Create(EventType eventType, string subject, string body)
+        public static NotificationTemplate CreateGlobal(EventType eventType, string subject, string body)
         {
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
@@ -27,6 +29,29 @@ namespace FertileNotify.Domain.Entities
                 throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
 
             return new NotificationTemplate(eventType, subject, body);
+        }
+
+        public static NotificationTemplate CreateCustom(Guid subscriberId, EventType eventType, string subject, string body)
+        {
+            if (string.IsNullOrWhiteSpace(subject))
+                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
+
+            if (string.IsNullOrWhiteSpace(body))
+                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
+
+            return new NotificationTemplate(eventType, subject, body, subscriberId);
+        }
+
+        public void Update(string subject, string body)
+        {
+            if (string.IsNullOrWhiteSpace(subject))
+                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
+
+            if (string.IsNullOrWhiteSpace(body))
+                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
+
+            SubjectTemplate = subject;
+            BodyTemplate = body;
         }
     }
 }

--- a/backend/FertileNotify.Domain/Events/EventCatalog.cs
+++ b/backend/FertileNotify.Domain/Events/EventCatalog.cs
@@ -4,15 +4,28 @@
     {
         private static readonly IReadOnlyCollection<EventType> _events =
         [
+            // Auth
             EventType.SubscriberRegistered,
-            EventType.TestForDevelop // for testing purposes
+            EventType.PasswordReset,
+            EventType.EmailVerified,
+            EventType.LoginAlert,
+            EventType.AccountLocked,
+
+            // E-Commerce
+            EventType.OrderCreated,
+            EventType.OrderShipped,
+            EventType.OrderDelivered,
+            EventType.OrderCancelled,
+            EventType.PaymentFailed,
+            EventType.SubscriptionRenewed,
+
+            // General
+            EventType.Campaign,
+            EventType.MonthlyNewsletter,
+            EventType.SupportTicketUpdated
         ];
 
-        public static bool IsSupported(EventType eventType)
-        {
-            return _events.Contains(eventType);
-        }
-
+        public static bool IsSupported(EventType eventType) => _events.Contains(eventType);
         public static IReadOnlyCollection<EventType> All => _events;
     }
 }

--- a/backend/FertileNotify.Domain/Events/EventType.cs
+++ b/backend/FertileNotify.Domain/Events/EventType.cs
@@ -9,25 +9,57 @@
             Name = name;
         }
 
-        public static readonly EventType SubscriberRegistered = new("SubscriberRegistered");
-        public static readonly EventType TestForDevelop = new("TestForDevelop");
+        // --- AUTH & ACCOUNT ---
+        public static readonly EventType SubscriberRegistered = new("SubscriberRegistered"); // Yeni üye
+        public static readonly EventType PasswordReset = new("PasswordReset"); // Şifre sıfırlama
+        public static readonly EventType EmailVerified = new("EmailVerified"); // E-posta doğrulandı
+        public static readonly EventType LoginAlert = new("LoginAlert"); // Yeni cihazdan giriş yapıldı
+        public static readonly EventType AccountLocked = new("AccountLocked"); // Hesap kilitlendi
+
+        // --- E-COMMERCE ---
+        public static readonly EventType OrderCreated = new("OrderCreated"); // Sipariş alındı
+        public static readonly EventType OrderShipped = new("OrderShipped"); // Kargo yola çıktı
+        public static readonly EventType OrderDelivered = new("OrderDelivered"); // Teslim edildi
+        public static readonly EventType OrderCancelled = new("OrderCancelled"); // İptal edildi
+        public static readonly EventType PaymentFailed = new("PaymentFailed"); // Ödeme başarısız
+        public static readonly EventType SubscriptionRenewed = new("SubscriptionRenewed"); // Abonelik yenilendi (Firma müşterisi için)
+
+        // --- GENERAL & MARKETING ---
+        public static readonly EventType Campaign = new("Campaign"); // Genel kampanya
+        public static readonly EventType MonthlyNewsletter = new("MonthlyNewsletter"); // Bülten
+        public static readonly EventType SupportTicketUpdated = new("SupportTicketUpdated"); // Destek talebi güncellendi
+        public static readonly EventType TestForDevelop = new("TestForDevelop"); // Geliştirme testi
 
         public static EventType From(string name)
         {
             return name switch
             {
+                // Auth
                 "SubscriberRegistered" => SubscriberRegistered,
-                "TestForDevelop" => TestForDevelop, // for testing purposes
-                _ => throw new Exception("Unknown event type")
+                "PasswordReset" => PasswordReset,
+                "EmailVerified" => EmailVerified,
+                "LoginAlert" => LoginAlert,
+                "AccountLocked" => AccountLocked,
+
+                // E-Commerce
+                "OrderCreated" => OrderCreated,
+                "OrderShipped" => OrderShipped,
+                "OrderDelivered" => OrderDelivered,
+                "OrderCancelled" => OrderCancelled,
+                "PaymentFailed" => PaymentFailed,
+                "SubscriptionRenewed" => SubscriptionRenewed,
+
+                // General
+                "Campaign" => Campaign,
+                "MonthlyNewsletter" => MonthlyNewsletter,
+                "SupportTicketUpdated" => SupportTicketUpdated,
+
+                _ => throw new Exception($"Unknown event type: {name}")
             };
         }
 
         public override string ToString() => Name;
-
-        public override bool Equals(object? obj)
-            => obj is EventType other && Name == other.Name;
-
-        public override int GetHashCode()
-            => Name.GetHashCode();
+        public override bool Equals(object? obj) => obj is EventType other && Name == other.Name;
+        public override int GetHashCode() => Name.GetHashCode();
     }
 }

--- a/backend/FertileNotify.Domain/Rules/SubscriptionEventPolicy.cs
+++ b/backend/FertileNotify.Domain/Rules/SubscriptionEventPolicy.cs
@@ -11,12 +11,38 @@ namespace FertileNotify.Domain.Rules
             {
                 SubscriptionPlan.Free =>
                 [
-                    EventType.SubscriberRegistered
+                    EventType.SubscriberRegistered,
+                    EventType.PasswordReset,
+                    EventType.EmailVerified,
+                    EventType.LoginAlert,
+
+                    EventType.OrderCancelled,
+                    EventType.OrderShipped,
+                    EventType.OrderDelivered,
+                    EventType.OrderCreated,
+                    EventType.PaymentFailed,
+
+                    EventType.Campaign,
+                    EventType.MonthlyNewsletter,
+                    EventType.SupportTicketUpdated
                 ],
 
                 SubscriptionPlan.Pro =>
                 [
-                    EventType.SubscriberRegistered
+                    EventType.SubscriberRegistered,
+                    EventType.PasswordReset,
+                    EventType.EmailVerified,
+                    EventType.LoginAlert,
+
+                    EventType.OrderCancelled,
+                    EventType.OrderShipped,
+                    EventType.OrderDelivered,
+                    EventType.OrderCreated,
+                    EventType.PaymentFailed,
+
+                    EventType.Campaign,
+                    EventType.MonthlyNewsletter,
+                    EventType.SupportTicketUpdated
                 ],
 
                 SubscriptionPlan.Enterprise =>

--- a/backend/FertileNotify.Infrastructure/Migrations/20260208105103_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260208105103_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260207072300_InitialCreate")]
+    [Migration("20260208105103_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -79,6 +79,9 @@ namespace FertileNotify.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
+
+                    b.Property<Guid?>("SubscriberId")
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 

--- a/backend/FertileNotify.Infrastructure/Migrations/20260208105103_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260208105103_InitialCreate.cs
@@ -33,6 +33,7 @@ namespace FertileNotify.Infrastructure.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubscriberId = table.Column<Guid>(type: "uuid", nullable: true),
                     EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     SubjectTemplate = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     BodyTemplate = table.Column<string>(type: "text", nullable: false)

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -77,6 +77,9 @@ namespace FertileNotify.Infrastructure.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
+                    b.Property<Guid?>("SubscriberId")
+                        .HasColumnType("uuid");
+
                     b.HasKey("Id");
 
                     b.ToTable("NotificationTemplates");

--- a/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
@@ -15,15 +15,70 @@ namespace FertileNotify.Infrastructure.Persistence
                 var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
                 await context.Database.MigrateAsync();
-
-                if (!await context.NotificationTemplates.AnyAsync())
+                
+                if (!await context.NotificationTemplates.AnyAsync(t => t.SubscriberId == null))
                 {
                     var templates = new List<NotificationTemplate>
                     {
-                        NotificationTemplate.Create(
+                        // --- AUTH ---
+                        NotificationTemplate.CreateGlobal(
                             EventType.SubscriberRegistered,
-                            "Welcome {Name}!",
-                            "Hello {Name}, thank you for joining the FertileNotify family. Your email address is: {Email}"
+                            "Welcome to {AppName}!",
+                            "Hi {Name}, thank you for joining us. We are excited to have you on board."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.PasswordReset,
+                            "Reset Your Password",
+                            "Hello {Name}, you requested a password reset. Use this code: {Code}. If you didn't request this, ignore this email."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.EmailVerified,
+                            "Email Verified Successfully",
+                            "Hi {Name}, your email address has been verified. You can now access all features."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.LoginAlert,
+                            "New Login Detected",
+                            "Hello {Name}, we detected a new login to your account from {Device} at {Time}."
+                        ),
+
+                        // --- E-COMMERCE ---
+                        NotificationTemplate.CreateGlobal(
+                            EventType.OrderCreated,
+                            "Order Confirmation #{OrderId}",
+                            "Dear {Name}, thank you for your order. Total amount: {Amount}. We will notify you when it ships."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.OrderShipped,
+                            "Your Order Has Shipped! #{OrderId}",
+                            "Great news {Name}! Your order is on its way. Tracking Number: {TrackingNumber}."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.OrderDelivered,
+                            "Order Delivered",
+                            "Hi {Name}, your order #{OrderId} has been delivered. Enjoy!"
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.PaymentFailed,
+                            "Payment Failed for Order #{OrderId}",
+                            "Hello {Name}, we couldn't process your payment. Please update your payment method to proceed."
+                        ),
+
+                        // --- GENERAL ---
+                        NotificationTemplate.CreateGlobal(
+                            EventType.Campaign,
+                            "{CampaignTitle}",
+                            "Hi {Name}, check out our latest offer: {CampaignDetails}. Don't miss out!"
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.MonthlyNewsletter,
+                            "{Month} Newsletter",
+                            "Hi {Name}, here are the updates for this month: {Updates}."
+                        ),
+                        NotificationTemplate.CreateGlobal(
+                            EventType.SupportTicketUpdated,
+                            "Update on Ticket #{TicketId}",
+                            "Hello {Name}, your support ticket has been updated. Status: {Status}. Reply: {Message}."
                         )
                     };
 

--- a/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
@@ -20,10 +20,32 @@ namespace FertileNotify.Infrastructure.Persistence
             await _context.SaveChangesAsync();
         }
 
-        public async Task<NotificationTemplate?> GetByEventTypeAsync(EventType eventType)
+        public async Task<NotificationTemplate?> GetTemplateAsync(EventType eventType, Guid? subscriberId)
         {
-            var allTemplates = await _context.NotificationTemplates.ToListAsync();
-            return allTemplates.FirstOrDefault(t => t.EventType.Equals(eventType));
+            if (subscriberId.HasValue)
+            {
+                var customTemplate = _context.NotificationTemplates
+                    .FirstOrDefault(t =>
+                        t.SubscriberId == subscriberId &&
+                        t.EventType == eventType 
+                    );
+                if (customTemplate != null) return customTemplate;
+            }
+
+            return await _context.NotificationTemplates
+                .FirstOrDefaultAsync(t => t.SubscriberId == null && t.EventType == eventType);
         }
+
+        public async Task<NotificationTemplate?> GetGlobalTemplateAsync(EventType eventType)
+            => await _context.NotificationTemplates.FirstOrDefaultAsync(t =>
+                    t.EventType == eventType
+                    && t.SubscriberId == null
+                    && t.EventType.Name == eventType.Name);
+
+        public async Task<NotificationTemplate?> GetCustomTemplateAsync(EventType eventType, Guid subscriberId)
+            => await _context.NotificationTemplates.FirstOrDefaultAsync(t =>
+                    t.EventType == eventType
+                    && t.SubscriberId == subscriberId
+                    && t.EventType.Name == eventType.Name);
     }
 }

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -68,8 +68,8 @@ namespace FertileNotify.Tests
             var subscription = Subscription.Create(subscriberId, SubscriptionPlan.Free);
             _mockSubRepo.Setup(x => x.GetBySubscriberIdAsync(subscriberId)).ReturnsAsync(subscription);
 
-            var template = NotificationTemplate.Create(EventType.SubscriberRegistered, "Subject {Name}", "Body");
-            _mockTemplateRepo.Setup(x => x.GetByEventTypeAsync(EventType.SubscriberRegistered)).ReturnsAsync(template);
+            var template = NotificationTemplate.CreateGlobal(EventType.SubscriberRegistered, "Subject {Name}", "Body");
+            _mockTemplateRepo.Setup(x => x.GetTemplateAsync(EventType.SubscriberRegistered, subscriberId)).ReturnsAsync(template);
 
             _mockEmailSender
                 .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))


### PR DESCRIPTION
Introduce per-subscriber (custom) and global notification templates and expand the event catalog.

Key changes:
- Add TemplatesController, CreateTemplateRequest model and FluentValidation validator to allow creating/updating subscriber-specific templates.
- Extend NotificationTemplate with SubscriberId, add CreateGlobal/CreateCustom factory methods and Update method.
- Update ITemplateRepository to expose GetTemplateAsync, GetGlobalTemplateAsync and GetCustomTemplateAsync.
- Implement repository logic in EfTemplateRepository to prefer custom templates for a subscriber and fall back to global templates.
- Update ProcessEventHandler to request templates using the subscriberId.
- Expand EventType and EventCatalog with many new event kinds (auth, e-commerce, general) and update SubscriptionEventPolicy to include them for plans.
- Add migration changes and model snapshot to persist SubscriberId on NotificationTemplates, and update DbSeeder to seed global templates for the new event types.
- Update tests to use the new template API and add [NonAction] attributes for helper methods in controllers.

Reason: enable tenant-specific/customized notification templates while keeping global defaults and broaden supported event types.