### PR TITLE
Add MJML visual & advanced editors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,12 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "axios": "^1.13.4",
+        "grapesjs": "^0.22.14",
+        "grapesjs-mjml": "^1.0.7",
+        "mjml-browser": "^4.18.0",
+        "monaco-editor": "^0.55.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.0"
@@ -619,6 +624,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -995,6 +1023,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/backbone": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.15.tgz",
+      "integrity": "sha512-WWeKtYlsIMtDyLbbhkb96taJMEbfQBnuz7yw1u0pkphCOtksemoWhIXhK74VRCY9hbjnsH3rsJu2uUiFtnsEYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1002,11 +1040,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.33.tgz",
+      "integrity": "sha512-SeyVJXlCZpEki5F0ghuYe+L+PprQta6nRZqhONt9F13dWBtR/ftoaIbdRQ7cis7womE+X2LKhsDdDtkkDhJS6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mjml": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@types/mjml/-/mjml-4.7.4.tgz",
+      "integrity": "sha512-vyi1vzWgMzFMwZY7GSZYX0GU0dmtC8vLHwpgk+NWmwbwRSrlieVyJ9sn5elodwUfklJM7yGl0zQeet1brKTWaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mjml-core": "*"
+      }
+    },
+    "node_modules/@types/mjml-core": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@types/mjml-core/-/mjml-core-4.15.2.tgz",
+      "integrity": "sha512-Q7SxFXgoX979HP57DEVsRI50TV8x1V4lfCA4Up9AvfINDM5oD/X9ARgfoyX1qS987JCnDLv85JjkqAjt3hZSiQ==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1038,6 +1100,25 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+      "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/underscore": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.13.0.tgz",
+      "integrity": "sha512-L6LBgy1f0EFQZ+7uSA57+n2g/s4Qs5r06Vwrwn0/nuK1de+adz00NWaztRQ30aEqw5qOaWbPI8u2cGQ52lj6VA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -1487,6 +1568,26 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/backbone": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==",
+      "license": "MIT",
+      "dependencies": {
+        "underscore": ">=1.8.3"
+      }
+    },
+    "node_modules/backbone-undo": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/backbone-undo/-/backbone-undo-0.2.6.tgz",
+      "integrity": "sha512-AsfpNiljLXlk7TcffDUu3EAUq7CxWbyTNwARWrql5XTzN4vh6WzEEBZYaKK4kTTz+iW1tSzqUooaGRIwO83kWA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "backbone": ">=1.0.0",
+        "underscore": ">=1.4.4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1684,6 +1785,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "5.63.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.0.tgz",
+      "integrity": "sha512-KlLWRPggDg2rBD1Mx7/EqEhaBdy+ybBCVh/efgjBDsPpMeEu6MbTAJzIT4TuCzvmbTEgvKOGzVT6wdBTNusqrg==",
+      "license": "MIT"
+    },
+    "node_modules/codemirror-formatting": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/codemirror-formatting/-/codemirror-formatting-1.0.0.tgz",
+      "integrity": "sha512-br9yM6eJI3pJHekEnoyHaBEb1B7XxxDjju+vRyBe8QGLp5saTIXXkZ+eFCTqXSAtI8QEZDFVEX2/SOjH2sVWRQ==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1845,6 +1958,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2421,6 +2543,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/grapesjs": {
+      "version": "0.22.14",
+      "resolved": "https://registry.npmjs.org/grapesjs/-/grapesjs-0.22.14.tgz",
+      "integrity": "sha512-UyHKGtB9YOQ4bmvhmwY3H7J6SO30qgIH4qRp1ucUlblS21btMxY90xwQuAVIi+EFGl0wi8v1NBEYvA52eIEfyg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/backbone": "1.4.15",
+        "backbone": "1.4.1",
+        "backbone-undo": "0.2.6",
+        "codemirror": "5.63.0",
+        "codemirror-formatting": "1.0.0",
+        "html-entities": "~1.4.0",
+        "promise-polyfill": "8.3.0",
+        "underscore": "1.13.1"
+      }
+    },
+    "node_modules/grapesjs-mjml": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/grapesjs-mjml/-/grapesjs-mjml-1.0.7.tgz",
+      "integrity": "sha512-w/Gug1IAbK6nCouV3uL2s5mz87ogU4YFWXeVs8Yu6osxVVyRdSsIdELMO9PihD2Zp0DDUAkJCaBjH8bi/d9nnQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/mjml": "^4.7.4",
+        "mjml-browser": "^4.13.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2486,6 +2634,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3008,6 +3162,18 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3086,6 +3252,22 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mjml-browser": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/mjml-browser/-/mjml-browser-4.18.0.tgz",
+      "integrity": "sha512-Y3kpr3IFBk3Wm7AwONZ5vDAX7FxAaMk+RKbcKKewsuGI9oNCOSM2dWNcWVFdzZ9PF7awoaCgBSQudnJaJbUiBA==",
+      "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -3473,6 +3655,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3776,6 +3964,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4007,6 +4201,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "axios": "^1.13.4",
+    "grapesjs": "^0.22.14",
+    "grapesjs-mjml": "^1.0.7",
+    "mjml-browser": "^4.18.0",
+    "monaco-editor": "^0.55.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,11 +3,16 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import HomePage from './pages/HomePage';
 import DashboardPage from './pages/DashboardPage';
+import EmailDesignPanelAdvancedPage from './pages/EmailDesignPanelAdvancedPage';
+import EmailDesignVisualEditorPage from './pages/EmailDesignVisualEditorPage';
+
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/email-advanced-editor" element={<EmailDesignPanelAdvancedPage />} />
+        <Route path="/email-visual-editor" element={<EmailDesignVisualEditorPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/pages/EmailDesignPanelAdvancedPage.tsx
+++ b/frontend/src/pages/EmailDesignPanelAdvancedPage.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import mjml2html from 'mjml-browser';
+import Editor from '@monaco-editor/react';
+
+const defaultMjml = `<mjml>
+  <mj-body background-color="#f0f2f5">
+    <mj-section background-color="white" padding="40px">
+      <mj-column>
+        <mj-text font-size="24px" color="#1f2937" align="center">
+          Hello {Name}!
+        </mj-text>
+        <mj-text font-size="16px" color="#4b5563" align="center">
+          Welcome to our service. Your email is {Email}.
+        </mj-text>
+        <mj-button background-color="#8b5cf6" href="{ActionUrl}">
+          Get Started
+        </mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>`;
+
+export default function EmailDesignPanelAdvancedPage() {
+  const [mjmlCode, setMjmlCode] = useState(defaultMjml);
+  const [emailSubject, setEmailSubject] = useState('');
+  const [activeTab, setActiveTab] = useState<'editor' | 'preview'>('editor');
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [templateName, setTemplateName] = useState('');
+  const [templateDescription, setTemplateDescription] = useState('');
+  const navigate = useNavigate();
+
+  const { html: htmlPreview, hasError, errorMsg } = useMemo(() => {
+    try {
+      const { html, errors } = mjml2html(mjmlCode);
+      if (errors && errors.length > 0) {
+        return { html: html || '', hasError: true, errorMsg: (errors[0] as { message: string }).message };
+      }
+      return { html, hasError: false, errorMsg: '' };
+    } catch (e) {
+      return { html: '', hasError: true, errorMsg: (e as Error).message };
+    }
+  }, [mjmlCode]);
+
+  const handleSave = () => {
+    console.log('Saving template:', { templateName, templateDescription, emailSubject, mjmlCode });
+    // TODO: API call to save template
+    setShowSaveModal(false);
+    setTemplateName('');
+    setTemplateDescription('');
+    setEmailSubject('');
+  };
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 text-white">
+      {/* Save Modal */}
+      {showSaveModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+          <div className="w-full max-w-md bg-gray-900 border border-purple-500/30 rounded-xl shadow-2xl p-6">
+            <h2 className="text-xl font-bold text-white mb-4">Save Template</h2>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Template Name</label>
+                <input
+                  type="text"
+                  value={templateName}
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  placeholder="Enter template name..."
+                  className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Description</label>
+                <textarea
+                  value={templateDescription}
+                  onChange={(e) => setTemplateDescription(e.target.value)}
+                  placeholder="Enter description..."
+                  rows={3}
+                  className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 mt-6">
+              <button
+                onClick={() => setShowSaveModal(false)}
+                className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={!templateName.trim()}
+                className="px-6 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Header */}
+      <header className="flex items-center justify-between px-6 py-4 bg-gray-900/80 backdrop-blur-md border-b border-purple-500/30">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+          </button>
+
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-600 to-pink-500 flex items-center justify-center">
+              <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-lg font-bold text-white">Code Editor</h1>
+              <p className="text-xs text-gray-400">MJML</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {hasError && (
+            <div className="px-3 py-1.5 bg-red-500/20 border border-red-500/30 rounded-lg text-red-400 text-xs">
+              Error
+            </div>
+          )}
+
+          <button
+            onClick={() => setShowSaveModal(true)}
+            className="px-5 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium text-sm hover:opacity-90 transition-opacity"
+          >
+            Save
+          </button>
+        </div>
+      </header>
+
+      {/* Email Subject Bar */}
+      <div className="px-6 py-3 bg-gray-900/50 border-b border-gray-800 flex items-center gap-4">
+        <label className="text-sm text-gray-400 whitespace-nowrap">Subject:</label>
+        <input
+          type="text"
+          value={emailSubject}
+          onChange={(e) => setEmailSubject(e.target.value)}
+          placeholder="Enter email subject... (use {Variable} for dynamic content)"
+          className="flex-1 px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 text-sm"
+        />
+      </div>
+
+      {/* Info Banner */}
+      <div className="px-6 py-2 bg-purple-900/20 border-b border-purple-500/20 flex items-center gap-2">
+        <svg className="w-4 h-4 text-purple-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <p className="text-xs text-purple-300">
+          <span className="font-medium">Tip:</span> Use <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Variable}'}</code> syntax for dynamic data. Example: <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Name}'}</code>, <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Email}'}</code>
+        </p>
+      </div>
+
+      {/* Mobile Tabs */}
+      <div className="flex md:hidden border-b border-gray-800">
+        {(['editor', 'preview'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`flex-1 py-3 text-xs font-medium uppercase ${activeTab === tab ? 'text-purple-400 border-b-2 border-purple-500' : 'text-gray-500'}`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Main Content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Editor */}
+        <div className={`flex flex-col flex-1 ${activeTab === 'editor' ? 'flex' : 'hidden md:flex'}`}>
+          <div className="px-4 py-2 bg-gray-900 border-b border-gray-800 flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-purple-500"></span>
+            <span className="text-xs text-gray-400 font-mono">template.mjml</span>
+          </div>
+          <div className="flex-1 relative">
+            <Editor
+              height="100%"
+              defaultLanguage="xml"
+              value={mjmlCode}
+              onChange={(value) => setMjmlCode(value || '')}
+              theme="vs-dark"
+              options={{
+                fontSize: 14,
+                minimap: { enabled: false },
+                padding: { top: 16 },
+                scrollBeyondLastLine: false,
+                wordWrap: 'on',
+              }}
+            />
+            {hasError && (
+              <div className="absolute bottom-4 left-4 right-4 bg-red-900/90 border border-red-500/50 p-3 rounded-lg">
+                <p className="text-xs text-red-300 font-mono">{errorMsg}</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Preview */}
+        <div className={`flex flex-col flex-1 border-l border-gray-800 ${activeTab === 'preview' ? 'flex' : 'hidden md:flex'}`}>
+          <div className="px-4 py-2 bg-gray-900 border-b border-gray-800 flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-green-400"></span>
+            <span className="text-xs text-gray-400 font-mono">preview</span>
+          </div>
+          <div className="flex-1 overflow-auto p-6 bg-gray-950">
+            <div className="max-w-[600px] mx-auto h-full bg-white rounded-lg overflow-hidden shadow-xl">
+              <iframe
+                srcDoc={htmlPreview}
+                title="Preview"
+                className="w-full h-full border-0"
+                sandbox="allow-same-origin allow-scripts"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/EmailDesignVisualEditorPage.tsx
+++ b/frontend/src/pages/EmailDesignVisualEditorPage.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import grapesjs, { type Editor as GjsEditor } from 'grapesjs';
+import gjsMjml from 'grapesjs-mjml';
+import 'grapesjs/dist/css/grapes.min.css';
+
+const defaultMjml = `
+<mjml>
+  <mj-body background-color="#f0f2f5">
+    <mj-section background-color="#ffffff" padding="40px">
+      <mj-column>
+        <mj-text font-size="24px" color="#1f2937" align="center">Hello {Name}!</mj-text>
+        <mj-text font-size="16px" color="#4b5563" align="center">
+          Welcome to our service.
+        </mj-text>
+        <mj-button background-color="#8b5cf6" href="#">Get Started</mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`;
+
+export default function VisualEmailEditor() {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const gjsRef = useRef<GjsEditor | null>(null);
+  const [emailSubject, setEmailSubject] = useState('');
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [templateName, setTemplateName] = useState('');
+  const [templateDescription, setTemplateDescription] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!editorRef.current) return;
+
+    const editor = grapesjs.init({
+      container: editorRef.current,
+      fromElement: false,
+      height: '100%',
+      width: 'auto',
+      plugins: [gjsMjml],
+      pluginsOpts: { 'grapesjs-mjml': {} },
+      storageManager: false,
+      panels: { defaults: [] },
+      blockManager: { appendTo: '#blocks-container' },
+      styleManager: { appendTo: '#styles-container' },
+      traitManager: { appendTo: '#traits-container' },
+      selectorManager: { appendTo: '#styles-container' },
+      deviceManager: {
+        devices: [
+          { name: 'Desktop', width: '' },
+          { name: 'Mobile', width: '320px' }
+        ]
+      }
+    });
+
+    gjsRef.current = editor;
+    editor.setComponents(defaultMjml);
+
+    setTimeout(() => {
+      if (editor) editor.refresh();
+    }, 200);
+
+    return () => editor.destroy();
+  }, []);
+
+  const handleSave = () => {
+    if (gjsRef.current) {
+      const mjml = gjsRef.current.getHtml();
+      console.log('Saving template:', { templateName, templateDescription, emailSubject, mjml });
+      // TODO: API call
+    }
+    setShowSaveModal(false);
+    setTemplateName('');
+    setTemplateDescription('');
+  };
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 text-white">
+      {/* GrapesJS Styles */}
+      <style dangerouslySetInnerHTML={{
+        __html: `
+        .gjs-cv-canvas {
+          background-color: transparent !important;
+          background-image: radial-gradient(#374151 1px, transparent 1px) !important;
+          background-size: 20px 20px !important;
+        }
+        .gjs-one-bg { background-color: transparent !important; }
+        .gjs-two-color { color: #9ca3af !important; }
+        .gjs-block {
+          background: #1f2937 !important;
+          border: 1px solid #374151 !important;
+          border-radius: 8px !important;
+          color: #e5e7eb !important;
+          transition: all 0.2s !important;
+          padding: 10px !important;
+        }
+        .gjs-block:hover {
+          border-color: #8b5cf6 !important;
+          background: #272f42 !important;
+        }
+        .gjs-block-label { font-size: 0.7rem !important; text-transform: uppercase; }
+        .gjs-field { background-color: #111827 !important; border: 1px solid #374151 !important; border-radius: 4px !important; color: white !important; }
+        .gjs-category-title, .gjs-sm-sector-title {
+          background-color: #111827 !important;
+          border-bottom: 1px solid #374151 !important;
+          color: #e5e7eb !important;
+          font-size: 0.7rem !important;
+          text-transform: uppercase !important;
+          padding: 12px !important;
+        }
+        .gjs-sm-property .gjs-sm-label { color: #9ca3af !important; font-size: 0.7rem !important; }
+        ::-webkit-scrollbar { width: 6px; }
+        ::-webkit-scrollbar-track { background: #111827; }
+        ::-webkit-scrollbar-thumb { background: #374151; border-radius: 3px; }
+      `}} />
+
+      {/* Save Modal */}
+      {showSaveModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+          <div className="w-full max-w-md bg-gray-900 border border-purple-500/30 rounded-xl shadow-2xl p-6">
+            <h2 className="text-xl font-bold text-white mb-4">Save Template</h2>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Template Name</label>
+                <input
+                  type="text"
+                  value={templateName}
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  placeholder="Enter template name..."
+                  className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Description</label>
+                <textarea
+                  value={templateDescription}
+                  onChange={(e) => setTemplateDescription(e.target.value)}
+                  placeholder="Enter description..."
+                  rows={3}
+                  className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 mt-6">
+              <button
+                onClick={() => setShowSaveModal(false)}
+                className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={!templateName.trim()}
+                className="px-6 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Header */}
+      <header className="flex items-center justify-between px-6 py-4 bg-gray-900/80 backdrop-blur-md border-b border-purple-500/30 shrink-0">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+          </button>
+
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center">
+              <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-lg font-bold text-white">Visual Editor</h1>
+              <p className="text-xs text-gray-400">Drag & Drop</p>
+            </div>
+          </div>
+        </div>
+
+        <button
+          onClick={() => setShowSaveModal(true)}
+          className="px-5 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium text-sm hover:opacity-90 transition-opacity"
+        >
+          Save
+        </button>
+      </header>
+
+      {/* Email Subject Bar */}
+      <div className="px-6 py-3 bg-gray-900/50 border-b border-gray-800 flex items-center gap-4 shrink-0">
+        <label className="text-sm text-gray-400 whitespace-nowrap">Subject:</label>
+        <input
+          type="text"
+          value={emailSubject}
+          onChange={(e) => setEmailSubject(e.target.value)}
+          placeholder="Enter email subject... (use {Variable} for dynamic content)"
+          className="flex-1 px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 text-sm"
+        />
+      </div>
+
+      {/* Info Banner */}
+      <div className="px-6 py-2 bg-purple-900/20 border-b border-purple-500/20 flex items-center gap-2 shrink-0">
+        <svg className="w-4 h-4 text-purple-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <p className="text-xs text-purple-300">
+          <span className="font-medium">Tip:</span> Use <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Variable}'}</code> syntax for dynamic data. Example: <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Name}'}</code>, <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Email}'}</code>
+        </p>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left Sidebar - Blocks */}
+        <div className="w-64 bg-gray-900 border-r border-gray-800 flex flex-col shrink-0">
+          <div className="px-4 py-3 border-b border-gray-800 text-xs font-medium text-gray-400 uppercase">
+            Blocks
+          </div>
+          <div id="blocks-container" className="flex-1 overflow-y-auto p-3"></div>
+        </div>
+
+        {/* Canvas */}
+        <div className="flex-1 overflow-hidden bg-black/50">
+          <div className="h-full" ref={editorRef}></div>
+        </div>
+
+        {/* Styles Sidebar */}
+        <div className="w-72 bg-gray-900 border-l border-gray-800 flex flex-col shrink-0">
+          <div className="px-4 py-3 border-b border-gray-800 text-xs font-medium text-gray-400 uppercase">
+            Settings
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <div id="styles-container"></div>
+            <div id="traits-container" className="border-t border-gray-800"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/mjml-browser.d.ts
+++ b/frontend/src/types/mjml-browser.d.ts
@@ -1,0 +1,11 @@
+declare module 'mjml-browser' {
+  type Mjml2HtmlOptions = Record<string, unknown>;
+
+  interface Mjml2HtmlResult {
+    html: string;
+    errors?: unknown[];
+  }
+
+  const mjml2html: (input: string, options?: Mjml2HtmlOptions) => Mjml2HtmlResult;
+  export default mjml2html;
+}


### PR DESCRIPTION
Introduce two new email template editors: a visual GrapesJS-based editor and an advanced code editor using Monaco. Added routes in App.tsx for /email-visual-editor and /email-advanced-editor. Implemented UI, save modal placeholders, MJML -> HTML preview (iframe) and error reporting in the code editor (mjml-browser). Added a minimal type declaration for mjml-browser. Updated package.json to include grapesjs, grapesjs-mjml, mjml-browser, monaco-editor and @monaco-editor/react and added corresponding lockfile entries; API save calls are left as TODOs.