### PR TITLE
Add Templates page and polish SMS UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import EmailDesignAdvancedPanelPage from './pages/EmailDesignAdvancedPanelPage';
 import EmailDesignVisualPanelPage from './pages/EmailDesignVisualPanelPage';
 import PricingPlanPage from './pages/PricingPlanPage';
 import SmsDesignPanelPage from './pages/SmsDesignPanelPage';
+import TemplatesPage from './pages/TemplatesPage';
 
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
         <Route path="/email-advanced-editor" element={<EmailDesignAdvancedPanelPage />} />
         <Route path="/email-visual-editor" element={<EmailDesignVisualPanelPage />} />
         <Route path="/sms-editor" element={<SmsDesignPanelPage />} />
+        <Route path="/templates" element={<TemplatesPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -264,12 +264,20 @@ export default function DashboardPage() {
                         <h1 className="text-2xl font-display font-semibold text-primary">Dashboard</h1>
                         <p className="text-sm text-secondary mt-1">Welcome back</p>
                     </div>
-                    <button
-                        onClick={handleLogout}
-                        className="px-4 py-2 text-sm bg-red-500/10 text-red-400 border border-red-500/20 rounded-md hover:bg-red-500/20 transition-colors"
-                    >
-                        Logout
-                    </button>
+                    <div className="flex items-center gap-3">
+                        <button
+                            onClick={() => navigate('/templates')}
+                            className="px-4 py-2 text-sm bg-primary-500/10 text-primary-400 border border-primary-500/20 rounded-md hover:bg-primary-500/20 transition-colors"
+                        >
+                            Templates
+                        </button>
+                        <button
+                            onClick={handleLogout}
+                            className="px-4 py-2 text-sm bg-red-500/10 text-red-400 border border-red-500/20 rounded-md hover:bg-red-500/20 transition-colors"
+                        >
+                            Logout
+                        </button>
+                    </div>
                 </div>
             </header>
 

--- a/frontend/src/pages/SmsDesignPanelPage.tsx
+++ b/frontend/src/pages/SmsDesignPanelPage.tsx
@@ -57,22 +57,22 @@ export default function SmsDesignPanelPage() {
     };
 
     return (
-        <div className="flex flex-col h-screen overflow-hidden bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 text-white">
+        <div className="flex flex-col h-screen overflow-hidden bg-primary text-primary">
             {/* Save Modal */}
             {showSaveModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-                    <div className="w-full max-w-md bg-gray-900 border border-purple-500/30 rounded-xl shadow-2xl p-6">
-                        <h2 className="text-xl font-bold text-white mb-4">Save SMS Template</h2>
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+                    <div className="w-full max-w-md card-elevated p-6">
+                        <h2 className="text-xl font-semibold text-primary mb-4">Save SMS Template</h2>
 
                         <div className="space-y-4">
                             {/* Event Type Selection */}
                             <div>
-                                <label className="block text-sm text-gray-400 mb-2">Event Type</label>
+                                <label className="block text-sm text-secondary mb-2">Event Type</label>
                                 <div className="relative">
                                     <select
                                         value={selectedEventType}
                                         onChange={(e) => setSelectedEventType(e.target.value)}
-                                        className="w-full px-4 py-2.5 bg-gray-800 border border-gray-700 rounded-lg text-white appearance-none focus:outline-none focus:border-purple-500 cursor-pointer"
+                                        className="input-modern appearance-none cursor-pointer"
                                     >
                                         <option value="" disabled>Select an event type...</option>
                                         {EVENT_TYPES.map((event) => (
@@ -82,7 +82,7 @@ export default function SmsDesignPanelPage() {
                                         ))}
                                     </select>
                                     <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-                                        <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <svg className="w-4 h-4 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                                         </svg>
                                     </div>
@@ -90,24 +90,24 @@ export default function SmsDesignPanelPage() {
                             </div>
 
                             <div>
-                                <label className="block text-sm text-gray-400 mb-1">Template Name</label>
+                                <label className="block text-sm text-secondary mb-2">Template Name</label>
                                 <input
                                     type="text"
                                     value={templateName}
                                     onChange={(e) => setTemplateName(e.target.value)}
                                     placeholder="Enter template name..."
-                                    className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                                    className="input-modern"
                                 />
                             </div>
 
                             <div>
-                                <label className="block text-sm text-gray-400 mb-1">Description</label>
+                                <label className="block text-sm text-secondary mb-2">Description</label>
                                 <textarea
                                     value={templateDescription}
                                     onChange={(e) => setTemplateDescription(e.target.value)}
                                     placeholder="Enter description..."
                                     rows={2}
-                                    className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none"
+                                    className="input-modern resize-none"
                                 />
                             </div>
                         </div>
@@ -115,14 +115,14 @@ export default function SmsDesignPanelPage() {
                         <div className="flex justify-end gap-3 mt-6">
                             <button
                                 onClick={() => setShowSaveModal(false)}
-                                className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+                                className="btn-secondary text-sm"
                             >
                                 Cancel
                             </button>
                             <button
                                 onClick={handleSave}
                                 disabled={!templateName.trim() || !selectedEventType}
-                                className="px-6 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="btn-primary text-sm disabled:opacity-50"
                             >
                                 Save
                             </button>
@@ -132,11 +132,11 @@ export default function SmsDesignPanelPage() {
             )}
 
             {/* Header */}
-            <header className="flex items-center justify-between px-6 py-4 bg-gray-900/80 backdrop-blur-md border-b border-purple-500/30">
+            <header className="flex items-center justify-between px-6 py-4 bg-secondary border-b border-primary">
                 <div className="flex items-center gap-4">
                     <button
                         onClick={() => navigate('/dashboard')}
-                        className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                        className="p-2 rounded-md bg-tertiary hover:bg-elevated text-secondary hover:text-primary transition-colors"
                     >
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
@@ -144,44 +144,44 @@ export default function SmsDesignPanelPage() {
                     </button>
 
                     <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center">
+                        <div className="w-10 h-10 rounded-md bg-primary-500 flex items-center justify-center shadow-lg shadow-primary-500/10">
                             <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
                             </svg>
                         </div>
                         <div>
-                            <h1 className="text-lg font-bold text-white">SMS Designer</h1>
-                            <p className="text-xs text-gray-400">Create SMS Templates</p>
+                            <h1 className="text-base font-semibold text-primary">SMS Designer</h1>
+                            <p className="text-xs text-secondary tracking-tight">Create Professional SMS Templates</p>
                         </div>
                     </div>
                 </div>
 
                 <button
                     onClick={() => setShowSaveModal(true)}
-                    className="px-5 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium text-sm hover:opacity-90 transition-opacity"
+                    className="btn-primary text-sm"
                 >
                     Save
                 </button>
             </header>
 
             {/* Info Banner */}
-            <div className="px-6 py-2 bg-purple-900/20 border-b border-purple-500/20 flex items-center gap-2">
-                <svg className="w-4 h-4 text-purple-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="px-6 py-2 bg-primary-500/5 border-b border-primary-500/10 flex items-center gap-2">
+                <svg className="w-4 h-4 text-primary-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <p className="text-xs text-purple-300">
-                    <span className="font-medium">Tip:</span> Use <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Variable}'}</code> syntax for dynamic data. Example: <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Name}'}</code>, <code className="px-1 py-0.5 bg-purple-500/20 rounded text-purple-200">{'{Code}'}</code>
+                <p className="text-xs text-secondary">
+                    <span className="font-medium">Tip:</span> Use <code className="px-1 py-0.5 bg-tertiary rounded text-primary-400">{'{Variable}'}</code> syntax for dynamic data. Example: <code className="px-1 py-0.5 bg-tertiary rounded text-primary-400">{'{Name}'}</code>, <code className="px-1 py-0.5 bg-tertiary rounded text-primary-400">{'{Code}'}</code>
                 </p>
             </div>
 
             {/* Warning Banner */}
             {showWarning && (
-                <div className="px-6 py-3 bg-yellow-900/20 border-b border-yellow-500/30 flex items-center gap-2">
-                    <svg className="w-5 h-5 text-yellow-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="px-6 py-3 bg-yellow-500/10 border-b border-yellow-500/20 flex items-center gap-2">
+                    <svg className="w-5 h-5 text-yellow-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
                     <p className="text-sm text-yellow-300">
-                        <span className="font-medium">Uyarı:</span> Mesaj içeriği ve başlığı ortalama bir mesajdan çok uzun oldu. SMS'i alan kişiler tamamını göremeyebilir.
+                        <span className="font-medium">Warning:</span> Message content or title is significantly longer than average. Some recipients might not see the full content.
                     </p>
                 </div>
             )}
@@ -189,17 +189,17 @@ export default function SmsDesignPanelPage() {
             {/* Main Content */}
             <div className="flex flex-1 overflow-hidden">
                 {/* Left Panel - SMS Form */}
-                <div className="flex-1 flex flex-col border-r border-gray-800 overflow-y-auto bg-gray-900/50">
-                    <div className="px-6 py-3 border-b border-gray-800 bg-gray-800/50">
-                        <h2 className="text-xs font-medium text-gray-300 uppercase tracking-wide">SMS Content</h2>
+                <div className="flex-1 flex flex-col border-r border-[#262626] overflow-y-auto bg-primary">
+                    <div className="px-6 py-3 border-b border-[#262626] bg-[#0a0a0a]">
+                        <h2 className="text-[10px] font-bold text-secondary uppercase tracking-widest">SMS Content</h2>
                     </div>
 
-                    <div className="flex-1 p-6 space-y-6">
+                    <div className="flex-1 p-8 space-y-8">
                         {/* Title Input */}
                         <div>
-                            <div className="flex items-center justify-between mb-2">
-                                <label className="block text-sm font-medium text-gray-300">Title</label>
-                                <span className={`text-xs ${isTitleTooLong ? 'text-yellow-400 font-medium' : 'text-gray-500'}`}>
+                            <div className="flex items-center justify-between mb-3">
+                                <label className="block text-sm font-semibold text-primary">Title</label>
+                                <span className={`text-[10px] font-mono ${isTitleTooLong ? 'text-yellow-500 font-bold' : 'text-secondary'}`}>
                                     {title.length} / {MAX_TITLE_LENGTH}
                                 </span>
                             </div>
@@ -208,11 +208,10 @@ export default function SmsDesignPanelPage() {
                                 value={title}
                                 onChange={(e) => setTitle(e.target.value)}
                                 placeholder="Enter SMS title..."
-                                className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white placeholder-gray-500 focus:outline-none transition-colors ${isTitleTooLong ? 'border-yellow-500 focus:border-yellow-400' : 'border-gray-700 focus:border-purple-500'
-                                    }`}
+                                className={`input-modern !bg-[#050505] !border-[#333] !py-3 ${isTitleTooLong ? 'border-yellow-500/50 focus:border-yellow-500' : 'focus:border-primary-500'}`}
                             />
                             {isTitleTooLong && (
-                                <p className="mt-1 text-xs text-yellow-400">
+                                <p className="mt-2 text-xs text-yellow-500/80">
                                     Title exceeds recommended length. It may be truncated in the notification.
                                 </p>
                             )}
@@ -220,9 +219,9 @@ export default function SmsDesignPanelPage() {
 
                         {/* Message Textarea */}
                         <div>
-                            <div className="flex items-center justify-between mb-2">
-                                <label className="block text-sm font-medium text-gray-300">Message</label>
-                                <span className={`text-xs ${isMessageTooLong ? 'text-yellow-400 font-medium' : 'text-gray-500'}`}>
+                            <div className="flex items-center justify-between mb-3">
+                                <label className="block text-sm font-semibold text-primary">Message</label>
+                                <span className={`text-[10px] font-mono ${isMessageTooLong ? 'text-yellow-500 font-bold' : 'text-secondary'}`}>
                                     {message.length} / {MAX_MESSAGE_LENGTH}
                                 </span>
                             </div>
@@ -230,96 +229,116 @@ export default function SmsDesignPanelPage() {
                                 value={message}
                                 onChange={(e) => setMessage(e.target.value)}
                                 placeholder="Enter your SMS message here... Use {Variable} for dynamic content."
-                                rows={10}
-                                className={`w-full px-4 py-3 bg-gray-800 border rounded-lg text-white placeholder-gray-500 focus:outline-none resize-none transition-colors ${isMessageTooLong ? 'border-yellow-500 focus:border-yellow-400' : 'border-gray-700 focus:border-purple-500'
-                                    }`}
+                                rows={8}
+                                className={`input-modern !bg-[#050505] !border-[#333] !py-4 resize-none ${isMessageTooLong ? 'border-yellow-500/50 focus:border-yellow-500' : 'focus:border-primary-500'}`}
                             />
                             {isMessageTooLong && (
-                                <p className="mt-1 text-xs text-yellow-400">
+                                <p className="mt-2 text-xs text-yellow-500/80">
                                     Message exceeds typical SMS length. Recipients may not see the full content.
                                 </p>
                             )}
                         </div>
 
                         {/* Info Card */}
-                        <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
-                            <h3 className="text-sm font-medium text-gray-300 mb-2">💡 Best Practices</h3>
-                            <ul className="space-y-1 text-xs text-gray-400">
-                                <li>• Keep titles under {MAX_TITLE_LENGTH} characters</li>
-                                <li>• Keep messages under {MAX_MESSAGE_LENGTH} characters</li>
-                                <li>• Use clear and concise language</li>
-                                <li>• Include a call-to-action when needed</li>
-                                <li>• Test with variables before sending</li>
+                        <div className="card-elevated p-6 !border-primary-500/20 !bg-primary-500/[0.03]">
+                            <h3 className="text-xs font-bold text-primary-400 mb-4 uppercase tracking-widest">💡 Best Practices</h3>
+                            <ul className="space-y-3 text-xs text-secondary">
+                                <li className="flex gap-3">
+                                    <span className="text-primary-500">•</span>
+                                    <span>Keep titles under <strong className="text-primary">{MAX_TITLE_LENGTH}</strong> characters for better visibility.</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <span className="text-primary-500">•</span>
+                                    <span>Keep messages under <strong className="text-primary">{MAX_MESSAGE_LENGTH}</strong> characters to avoid multi-part SMS.</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <span className="text-primary-500">•</span>
+                                    <span>Use clear, action-oriented language to improve engagement.</span>
+                                </li>
                             </ul>
                         </div>
                     </div>
                 </div>
 
                 {/* Right Panel - Phone Preview */}
-                <div className="flex-1 flex flex-col bg-gradient-to-br from-gray-800 via-gray-900 to-black">
-                    <div className="px-6 py-3 border-b border-gray-700 bg-gray-800/30">
-                        <h2 className="text-xs font-medium text-gray-300 uppercase tracking-wide">Preview</h2>
+                <div className="flex-1 flex flex-col bg-[#050505] overflow-hidden relative">
+                    {/* Background Pattern */}
+                    <div className="absolute inset-0 opacity-[0.05] pointer-events-none" style={{ backgroundImage: 'radial-gradient(#ffffff 1px, transparent 1px)', backgroundSize: '32px 32px' }}></div>
+                    <div className="absolute inset-0 bg-gradient-to-b from-transparent via-primary-500/[0.02] to-primary-500/[0.05]"></div>
+
+                    <div className="px-6 py-3 border-b border-[#262626] bg-[#0a0a0a]/80 backdrop-blur-sm relative z-10">
+                        <h2 className="text-[10px] font-bold text-secondary uppercase tracking-widest">Live Preview</h2>
                     </div>
 
-                    <div className="flex-1 flex items-center justify-center p-6">
+                    <div className="flex-1 flex items-center justify-center p-8 relative z-10">
                         {/* Phone Mockup */}
-                        <div className="relative w-80 h-[640px]">
+                        <div className="relative w-[280px] h-[580px] animate-slide-up group">
+                            {/* Outer Frame Highlight (Glow) */}
+                            <div className="absolute -inset-1 bg-gradient-to-b from-white/10 to-transparent rounded-[3.5rem] blur-sm opacity-50 group-hover:opacity-100 transition-opacity"></div>
+
                             {/* Phone Frame */}
-                            <div className="absolute inset-0 bg-gradient-to-b from-gray-700 to-gray-800 rounded-[3rem] border-[12px] border-gray-600 shadow-2xl overflow-hidden">
+                            <div className="absolute inset-0 bg-[#000] rounded-[3.2rem] border-[8px] border-[#1f1f1f] shadow-[0_0_40px_-10px_rgba(0,0,0,0.8)] overflow-hidden ring-1 ring-white/20">
                                 {/* Phone Notch */}
-                                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-40 h-7 bg-gray-900 rounded-b-3xl z-10 shadow-lg"></div>
+                                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-28 h-6 bg-[#000] rounded-b-2xl z-20"></div>
 
                                 {/* Phone Screen */}
-                                <div className="h-full bg-gradient-to-br from-sky-100 via-indigo-50 to-purple-100 overflow-hidden">
+                                <div className="h-full bg-black overflow-hidden flex flex-col">
                                     {/* Status Bar */}
-                                    <div className="h-12 bg-gray-900 flex items-center justify-between px-6 pt-2">
-                                        <span className="text-white text-xs font-medium">9:41</span>
-                                        <div className="flex items-center gap-1">
-                                            <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
-                                                <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
-                                            </svg>
-                                            <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                                            </svg>
-                                            <div className="w-6 h-3 border-2 border-white rounded-sm relative">
-                                                <div className="absolute inset-0.5 bg-white rounded-sm"></div>
+                                    <div className="h-10 flex items-center justify-between px-8 pt-3">
+                                        <span className="text-white text-[10px] font-bold">9:41</span>
+                                        <div className="flex items-center gap-1.5">
+                                            <div className="flex gap-0.5">
+                                                <div className="w-0.5 h-1.5 bg-white rounded-full"></div>
+                                                <div className="w-0.5 h-2 bg-white rounded-full"></div>
+                                                <div className="w-0.5 h-2.5 bg-white rounded-full"></div>
+                                                <div className="w-0.5 h-2.5 bg-white/30 rounded-full"></div>
+                                            </div>
+                                            <div className="w-4 h-2 rounded-[2px] border border-white/40 relative">
+                                                <div className="absolute inset-[1px] bg-white rounded-[1px] w-[80%]"></div>
                                             </div>
                                         </div>
                                     </div>
 
-                                    {/* Notification */}
-                                    <div className="mt-4 mx-3">
-                                        <div className="bg-white/95 backdrop-blur-xl rounded-2xl shadow-2xl overflow-hidden border border-gray-100">
+                                    {/* App Notification Container */}
+                                    <div className="mt-6 mx-3">
+                                        <div className="bg-[#1c1c1e] rounded-2xl overflow-hidden shadow-2xl border border-white/10">
                                             {/* App Header */}
-                                            <div className="flex items-center gap-3 px-4 py-3 bg-gradient-to-r from-white/90 to-white/70 border-b border-gray-100">
-                                                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center shrink-0 shadow-md">
-                                                    <span className="text-white text-sm font-bold">A</span>
+                                            <div className="flex items-center gap-3 px-4 py-3 bg-white/[0.03] border-b border-white/5">
+                                                <div className="w-8 h-8 rounded-lg bg-primary-500 flex items-center justify-center shrink-0 shadow-lg shadow-primary-500/20">
+                                                    <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                                                    </svg>
                                                 </div>
                                                 <div className="flex-1 min-w-0">
-                                                    <p className="text-xs font-semibold text-gray-900">Your App Name</p>
-                                                    <p className="text-xs text-gray-500">now</p>
+                                                    <div className="flex items-center justify-between">
+                                                        <p className="text-[11px] font-bold text-white tracking-tight">Fertile-Notify</p>
+                                                        <p className="text-[9px] text-white/40 uppercase font-bold tracking-wider">now</p>
+                                                    </div>
                                                 </div>
                                             </div>
 
                                             {/* SMS Content */}
-                                            <div className="px-4 py-3 bg-white">
+                                            <div className="px-4 py-4">
                                                 {title ? (
-                                                    <h3 className="text-sm font-semibold text-gray-900 mb-1">
+                                                    <h3 className="text-[13px] font-bold text-white mb-2 leading-tight">
                                                         {truncateText(title, MAX_TITLE_LENGTH)}
                                                     </h3>
                                                 ) : (
-                                                    <h3 className="text-sm font-semibold text-gray-400 mb-1">SMS Title</h3>
+                                                    <h3 className="text-[13px] font-bold text-white/20 mb-2">SMS Title</h3>
                                                 )}
                                                 {message ? (
-                                                    <p className="text-sm text-gray-700 whitespace-pre-wrap break-words leading-relaxed">
+                                                    <p className="text-[13px] text-white/80 whitespace-pre-wrap break-words leading-snug tracking-tight">
                                                         {truncateText(message, MAX_MESSAGE_LENGTH)}
                                                     </p>
                                                 ) : (
-                                                    <p className="text-sm text-gray-400">Your message will appear here...</p>
+                                                    <p className="text-[13px] text-white/20 italic">Your message will appear here...</p>
                                                 )}
                                             </div>
                                         </div>
                                     </div>
+
+                                    {/* Simple Home Indicator */}
+                                    <div className="mt-auto mb-2 mx-auto w-32 h-1 bg-white/10 rounded-full"></div>
                                 </div>
                             </div>
                         </div>

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface Template {
+    id: string;
+    name: string;
+    description: string;
+    type: 'Email' | 'SMS' | 'Console';
+    eventType: string;
+    source: 'Default' | 'Custom';
+    updatedAt: string;
+}
+
+const MOCK_TEMPLATES: Template[] = [
+    {
+        id: '1',
+        name: 'Welcome Email',
+        description: 'Standard welcome email for new subscribers.',
+        type: 'Email',
+        eventType: 'SubscriberRegistered',
+        source: 'Default',
+        updatedAt: '2024-02-12',
+    },
+    {
+        id: '2',
+        name: 'Password Recovery SMS',
+        description: 'OTP code delivery for password resets.',
+        type: 'SMS',
+        eventType: 'PasswordReset',
+        source: 'Default',
+        updatedAt: '2024-02-11',
+    },
+    {
+        id: '3',
+        name: 'Custom Login Alert',
+        description: 'Personalized console alert for security notifications.',
+        type: 'Console',
+        eventType: 'LoginAlert',
+        source: 'Custom',
+        updatedAt: '2024-02-13',
+    },
+];
+
+export default function TemplatesPage() {
+    const navigate = useNavigate();
+    const [search, setSearch] = useState('');
+    const [filterType, setFilterType] = useState('All');
+    const [filterSource, setFilterSource] = useState('All');
+    const [showCreateDropdown, setShowCreateDropdown] = useState(false);
+
+    const filteredTemplates = MOCK_TEMPLATES.filter(t => {
+        const matchesSearch = t.name.toLowerCase().includes(search.toLowerCase()) ||
+            t.description.toLowerCase().includes(search.toLowerCase());
+        const matchesType = filterType === 'All' || t.type === filterType;
+        const matchesSource = filterSource === 'All' || t.source === filterSource;
+        return matchesSearch && matchesType && matchesSource;
+    });
+
+    return (
+        <div className="min-h-screen bg-primary text-primary flex flex-col items-center py-12 px-4 animate-fade-in relative">
+            {/* Back Button */}
+            <button
+                onClick={() => navigate("/dashboard")}
+                className="absolute top-8 left-8 text-secondary hover:text-primary transition-smooth flex items-center gap-2 text-sm"
+            >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Dashboard
+            </button>
+
+            <div className="max-w-6xl w-full space-y-8 pt-8">
+                {/* Header Section */}
+                <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+                    <div className="space-y-2">
+                        <h1 className="text-3xl font-display font-bold tracking-tight text-primary">Templates</h1>
+                        <p className="text-secondary text-sm">Manage and customize your notification blueprints.</p>
+                    </div>
+
+                    <div className="relative">
+                        <button
+                            className="btn-primary flex items-center gap-2 text-sm px-6"
+                            onClick={() => setShowCreateDropdown(!showCreateDropdown)}
+                        >
+                            <span>Create New</span>
+                            <svg className={`w-4 h-4 transition-transform ${showCreateDropdown ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                            </svg>
+                        </button>
+
+                        {showCreateDropdown && (
+                            <div className="absolute right-0 mt-2 w-56 card-elevated z-50 overflow-hidden animate-slide-up shadow-2xl">
+                                <button className="w-full px-4 py-3 text-left text-sm hover:bg-tertiary transition-colors flex items-center gap-3">
+                                    <span className="text-primary-400">📧</span> Email Template
+                                </button>
+                                <button className="w-full px-4 py-3 text-left text-sm hover:bg-tertiary transition-colors flex items-center gap-3 border-t border-primary">
+                                    <span className="text-primary-400">💬</span> SMS Template
+                                </button>
+                                <button className="w-full px-4 py-3 text-left text-sm hover:bg-tertiary transition-colors flex items-center gap-3 border-t border-primary">
+                                    <span className="text-primary-400">🖥️</span> Console Template
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* Filters Row */}
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div className="md:col-span-2">
+                        <input
+                            type="text"
+                            placeholder="Search templates..."
+                            className="input-modern w-full"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                    </div>
+                    <select
+                        className="input-modern cursor-pointer"
+                        value={filterType}
+                        onChange={(e) => setFilterType(e.target.value)}
+                    >
+                        <option value="All">All Methods</option>
+                        <option value="Email">Email</option>
+                        <option value="SMS">SMS</option>
+                        <option value="Console">Console</option>
+                    </select>
+                    <select
+                        className="input-modern cursor-pointer"
+                        value={filterSource}
+                        onChange={(e) => setFilterSource(e.target.value)}
+                    >
+                        <option value="All">All Creators</option>
+                        <option value="Default">Default (System)</option>
+                        <option value="Custom">Custom (User)</option>
+                    </select>
+                </div>
+
+                {/* Templates Grid */}
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {filteredTemplates.map(template => (
+                        <div key={template.id} className="card p-6 flex flex-col justify-between group hover:border-hover transition-smooth">
+                            <div className="space-y-4">
+                                <div className="flex justify-between items-start">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-xl">
+                                            {template.type === 'Email' ? '📧' : template.type === 'SMS' ? '💬' : '🖥️'}
+                                        </span>
+                                        <span className={`badge ${template.source === 'Default' ? 'text-blue-400 border-blue-500/20' : 'text-purple-400 border-purple-500/20'}`}>
+                                            {template.source}
+                                        </span>
+                                    </div>
+                                    <span className="text-[10px] text-tertiary uppercase font-medium tracking-widest">{template.updatedAt}</span>
+                                </div>
+
+                                <div>
+                                    <h3 className="text-lg font-semibold text-primary group-hover:text-primary-400 transition-colors uppercase tracking-tight">
+                                        {template.name}
+                                    </h3>
+                                    <p className="text-secondary text-sm mt-1 line-clamp-2 leading-relaxed">
+                                        {template.description}
+                                    </p>
+                                </div>
+
+                                <div className="pt-2">
+                                    <div className="inline-flex items-center gap-1.5 px-2 py-1 bg-tertiary border border-primary rounded text-[11px] text-primary-400 font-mono">
+                                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                                        </svg>
+                                        {template.eventType}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="flex flex-col gap-2 mt-8 pt-4 border-t border-primary">
+                                {template.type === "Email" ? (
+                                    <div className="flex gap-2 w-full">
+                                        <button
+                                            className="btn-secondary flex-1 text-[10px] py-2 h-auto"
+                                            onClick={() => navigate("/email-visual-editor")}
+                                        >
+                                            Visual Editor
+                                        </button>
+                                        <button
+                                            className="btn-secondary flex-1 text-[10px] py-2 h-auto"
+                                            onClick={() => navigate("/email-advanced-editor")}
+                                        >
+                                            Advanced
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <button
+                                        className="btn-secondary flex-1 text-xs py-2 h-auto"
+                                        onClick={() => navigate(template.type === "SMS" ? "/sms-editor" : "/console-editor")}
+                                    >
+                                        Edit {template.type}
+                                    </button>
+                                )}
+                                <button className="btn-secondary text-xs py-2 h-auto px-3 hover:text-red-400 hover:border-red-500/30 flex items-center justify-center gap-2">
+                                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                    </svg>
+                                    <span className="text-[10px] uppercase font-bold tracking-wider">Delete</span>
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {filteredTemplates.length === 0 && (
+                    <div className="card p-12 text-center space-y-4">
+                        <h3 className="text-primary font-medium">No templates found</h3>
+                        <p className="text-secondary text-sm max-w-xs mx-auto text-balance">
+                            We couldn't find any templates matching your search or filters. Try adjusting them!
+                        </p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Introduce a new TemplatesPage (mock data, search, type/source filters, create dropdown, template cards with actions) and wire it into the app routes (import + /templates route in App.tsx). Update DashboardPage to add a "Templates" button that navigates to the new page. Large visual/UI refactor of SmsDesignPanelPage: restyled header, modals, inputs, buttons and info banners, improved phone/notification preview, refined copy (warnings/tips) and layout tweaks for better readability and consistency. Files changed: frontend/src/pages/TemplatesPage.tsx (new), frontend/src/pages/SmsDesignPanelPage.tsx (UI updates), frontend/src/pages/DashboardPage.tsx (add button), frontend/src/App.tsx (import + route).