### PR TITLE
Add custom-query endpoint and validator

### DIFF
--- a/backend/FertileNotify.API/Models/GetAllCustomTemplatesRequest.cs
+++ b/backend/FertileNotify.API/Models/GetAllCustomTemplatesRequest.cs
@@ -1,0 +1,13 @@
+﻿namespace FertileNotify.API.Models
+{
+    public class GetCustomTemplatesRequest
+    {
+        public GetCustomTemplateQuery[] Queries { get; set; } = default!;
+    }
+
+    public class GetCustomTemplateQuery
+    {
+        public string EventType { get; set; } = string.Empty;
+        public string Channel { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Validators/GetCustomTemplatesRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/GetCustomTemplatesRequestValidator.cs
@@ -1,0 +1,34 @@
+﻿using FluentValidation;
+using FertileNotify.API.Models;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+
+namespace FertileNotify.API.Validators
+{
+    public class GetCustomTemplatesRequestValidator : AbstractValidator<GetCustomTemplatesRequest>
+    {
+        public GetCustomTemplatesRequestValidator() 
+        {
+            RuleFor(x => x.Queries)
+                .NotEmpty().WithMessage("Empty queries are not allowed.")
+                .Must(QueryParametersValid).WithMessage("Query parameters cannot be empty or meaningless.");
+        }
+
+        private bool QueryParametersValid(GetCustomTemplateQuery[] queries)
+        {
+            foreach (var query in queries)
+            {
+                if (string.IsNullOrEmpty(query.EventType))
+                {
+                    if (EventType.From(query.EventType) == null) return false;
+                }
+
+                if (string.IsNullOrEmpty(query.Channel))
+                {
+                    if (NotificationChannel.From(query.Channel) == null) return false;
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Introduce a new POST /custom-query endpoint in TemplatesController to fetch multiple custom notification templates in a single request. Adds GetCustomTemplatesRequest and GetCustomTemplateQuery models and a FluentValidation-based GetCustomTemplatesRequestValidator to validate incoming queries. Controller maps each query to EventType and NotificationChannel, retrieves matching templates and returns a simplified projection (Event, Channel, Subject, Body). Also adds a POST /create-or-update-custom route for create/update behavior and tidies using directives.