### PR TITLE
Add GET all templates endpoint and repo method

### DIFF
--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -22,6 +22,23 @@ namespace FertileNotify.API.Controllers
             _templateRepository = templateRepository;
         }
 
+        [HttpGet]
+        public async Task<IActionResult> GetAllTemplates()
+        {
+            var subscriberId = GetSubscriberIdFromClaims();
+            var templates = await _templateRepository.GetAllTemplatesAsync(subscriberId);
+
+            return Ok(templates.Select(t => new
+            {
+                Id = t.Id,
+                Event = t.EventType.Name,
+                Channel = t.Channel.Name,
+                Subject = t.SubjectTemplate,
+                Body = t.BodyTemplate,
+                Source = t.SubscriberId == null ? "Default" : "Custom"
+            }));
+        }
+
         [HttpPost("query")]
         public async Task<IActionResult> GetTemplates([FromBody] GetTemplatesRequest request)
         {
@@ -41,6 +58,7 @@ namespace FertileNotify.API.Controllers
             }
 
             return Ok(templates.Select(t => new {
+                Id = t.Id,
                 Event = t.EventType.Name,
                 Channel = t.Channel.Name,
                 Subject = t.SubjectTemplate,

--- a/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/ITemplateRepository.cs
@@ -9,6 +9,7 @@ namespace FertileNotify.Application.Interfaces
         Task<NotificationTemplate?> GetTemplateAsync(EventType eventType, NotificationChannel channel, Guid? subscriberId);
         Task<NotificationTemplate?> GetGlobalTemplateAsync(EventType eventType, NotificationChannel channel);
         Task<NotificationTemplate?> GetCustomTemplateAsync(EventType eventType, NotificationChannel channel, Guid subscriberId);
+        Task<List<NotificationTemplate>> GetAllTemplatesAsync(Guid subscriberId);
         Task AddAsync(NotificationTemplate template);
         Task SaveAsync();
     }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
@@ -46,5 +46,18 @@ namespace FertileNotify.Infrastructure.Persistence
             EventType eventType, NotificationChannel channel, Guid subscriberId)
             => await _context.NotificationTemplates.FirstOrDefaultAsync(t =>
                     t.SubscriberId == subscriberId && t.EventType == eventType && t.Channel == channel);
+
+        public async Task<List<NotificationTemplate>> GetAllTemplatesAsync(Guid subscriberId)
+        {
+            var globalTemplates = await _context.NotificationTemplates
+                .Where(t => t.SubscriberId == null)
+                .ToListAsync();
+
+            var customTemplates = await _context.NotificationTemplates
+                .Where(t => t.SubscriberId == subscriberId)
+                .ToListAsync();
+
+            return globalTemplates.Concat(customTemplates).ToList();
+        }
     }
 }


### PR DESCRIPTION
Expose a new GET /templates endpoint that returns both global (default) and custom templates for the requesting subscriber, including an explicit Source field ("Default" or "Custom").

Implemented repository support by adding GetAllTemplatesAsync(Guid) to ITemplateRepository and providing an EF implementation that loads global templates (SubscriberId == null) and the subscriber's custom templates, then concatenates them. Also fixed template mappings to include the template Id in the query response.