### PR TITLE
Add name and description to templates

### DIFF
--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -31,6 +31,8 @@ namespace FertileNotify.API.Controllers
             return Ok(templates.Select(t => new
             {
                 Id = t.Id,
+                Name = t.Name,
+                Description = t.Description,
                 Event = t.EventType.Name,
                 Channel = t.Channel.Name,
                 Subject = t.SubjectTemplate,
@@ -57,12 +59,16 @@ namespace FertileNotify.API.Controllers
                     templates.Add(template);
             }
 
-            return Ok(templates.Select(t => new {
+            return Ok(templates.Select(t => new
+            {
                 Id = t.Id,
+                Name = t.Name,
+                Description = t.Description,
                 Event = t.EventType.Name,
                 Channel = t.Channel.Name,
                 Subject = t.SubjectTemplate,
-                Body = t.BodyTemplate
+                Body = t.BodyTemplate,
+                Source = t.SubscriberId == null ? "Default" : "Custom"
             }));
         }
 
@@ -77,12 +83,20 @@ namespace FertileNotify.API.Controllers
 
             if (existingTemplate != null)
             {
-                existingTemplate.Update(request.SubjectTemplate, request.BodyTemplate);
+                existingTemplate.Update(request.Name, request.Description, request.SubjectTemplate, request.BodyTemplate);
                 await _templateRepository.SaveAsync();
             }
             else
             {
-                var newTemplate = NotificationTemplate.CreateCustom(subscriberId, eventType, channel, request.SubjectTemplate, request.BodyTemplate);
+                var newTemplate = NotificationTemplate.CreateCustom(
+                    subscriberId, 
+                    request.Name, 
+                    request.Description, 
+                    eventType, 
+                    channel, 
+                    request.SubjectTemplate, 
+                    request.BodyTemplate
+                );
                 await _templateRepository.AddAsync(newTemplate);
             }
 

--- a/backend/FertileNotify.API/Models/CreateTemplateRequest.cs
+++ b/backend/FertileNotify.API/Models/CreateTemplateRequest.cs
@@ -2,6 +2,8 @@
 {
     public class CreateTemplateRequest
     {
+        public string Name { get; set; } = null!;
+        public string Description { get; set; } = null!;
         public string EventType { get; set; } = null!;
         public string Channel { get; set; } = null!;
         public string SubjectTemplate { get; set; } = null!;

--- a/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
@@ -8,6 +8,14 @@ namespace FertileNotify.API.Validators
     {
         public CreateTemplateRequestValidator()
         {
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Name is required")
+                .MaximumLength(100).WithMessage("The template name exceeds the character limit.");
+
+            RuleFor(x => x.Description)
+                .NotEmpty().WithMessage("Name is required")
+                .MaximumLength(250).WithMessage("The template description exceeds the character limit.");
+
             RuleFor(x => x.EventType)
                 .NotEmpty().WithMessage("EventType is required.")
                 .Must(BeAValidEventType).WithMessage("Invalid EventType.");

--- a/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
@@ -7,6 +7,8 @@ namespace FertileNotify.Domain.Entities
     {
         public Guid Id { get; private set; }
         public Guid? SubscriberId { get; private set; }
+        public string Name { get; private set; } = string.Empty;
+        public string? Description { get; private set; } = string.Empty;
         public EventType EventType { get; private set; } = default!;
         public NotificationChannel Channel { get; private set; } = default!;
         public string SubjectTemplate { get; private set; } = string.Empty;
@@ -14,27 +16,29 @@ namespace FertileNotify.Domain.Entities
 
         private NotificationTemplate() { }
 
-        private NotificationTemplate(EventType eventType, NotificationChannel channel, string subject, string body, Guid? subscriberId)
+        private NotificationTemplate(string name, string description, EventType eventType, NotificationChannel channel, string subject, string body, Guid? subscriberId)
         {
             Id = Guid.NewGuid();
             SubscriberId = subscriberId;
+            Name = name;
+            Description = description;
             EventType = eventType;
             Channel = channel;
             SubjectTemplate = subject;
             BodyTemplate = body;
         }
 
-        public static NotificationTemplate CreateGlobal(EventType eventType, NotificationChannel channel, string subject, string body)
+        public static NotificationTemplate CreateGlobal(string name, string description, EventType eventType, NotificationChannel channel, string subject, string body)
         {
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
             if (string.IsNullOrWhiteSpace(body))
                 throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
 
-            return new NotificationTemplate(eventType, channel, subject, body, null);
+            return new NotificationTemplate(name, description, eventType, channel, subject, body, null);
         }
 
-        public static NotificationTemplate CreateCustom(Guid subscriberId, EventType eventType, NotificationChannel channel, string subject, string body)
+        public static NotificationTemplate CreateCustom(Guid subscriberId, string name, string description, EventType eventType, NotificationChannel channel, string subject, string body)
         {
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
@@ -42,16 +46,25 @@ namespace FertileNotify.Domain.Entities
             if (string.IsNullOrWhiteSpace(body))
                 throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
 
-            return new NotificationTemplate(eventType, channel, subject, body, subscriberId);
+            return new NotificationTemplate(name, description, eventType, channel, subject, body, subscriberId);
         }
 
-        public void Update(string subject, string body)
+        public void Update(string name, string description, string subject, string body)
         {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("name", nameof(name));
+
+            if (string.IsNullOrWhiteSpace(description))
+                throw new ArgumentException("description", nameof(description));
+
             if (string.IsNullOrWhiteSpace(subject))
                 throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
 
             if (string.IsNullOrWhiteSpace(body))
                 throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
+
+            Name = name;
+            Description = description;
 
             SubjectTemplate = subject;
             BodyTemplate = body;

--- a/backend/FertileNotify.Infrastructure/Migrations/20260219083451_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260219083451_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260210101854_InitialCreate")]
+    [Migration("20260219083451_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -75,10 +75,20 @@ namespace FertileNotify.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
                     b.Property<string>("EventType")
                         .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("SubjectTemplate")
                         .IsRequired()

--- a/backend/FertileNotify.Infrastructure/Migrations/20260219083451_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260219083451_InitialCreate.cs
@@ -34,6 +34,8 @@ namespace FertileNotify.Infrastructure.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     SubscriberId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
                     EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     Channel = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     SubjectTemplate = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -72,10 +72,20 @@ namespace FertileNotify.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)");
+
                     b.Property<string>("EventType")
                         .IsRequired()
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("SubjectTemplate")
                         .IsRequired()

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationTemplateConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationTemplateConfiguration.cs
@@ -12,6 +12,14 @@ namespace FertileNotify.Infrastructure.Persistence.Configurations
         {
             builder.HasKey(t => t.Id);
 
+            builder.Property(t => t.Name)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(t => t.Description)
+                .HasMaxLength(250)
+                .IsRequired();
+
             builder.Property(t => t.EventType)
                 .HasConversion(
                     eventType => eventType.Name, 

--- a/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
@@ -33,6 +33,8 @@ namespace FertileNotify.Infrastructure.Persistence
 
                         // --- AUTH EVENTS ---
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "User Welcome Message",
+                            "Sent to new subscribers immediately after registration to welcome them to the platform.",
                             EventType.SubscriberRegistered,
                             channel,
                             "Welcome to {AppName}!",
@@ -41,6 +43,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Password Reset Request",
+                            "Contains the security code or link required for a user to reset their forgotten password.",
                             EventType.PasswordReset,
                             channel,
                             "Reset Your Password",
@@ -49,6 +53,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Email Verification Success",
+                            "Confirmation sent once the user successfully verifies their email address.",
                             EventType.EmailVerified,
                             channel,
                             "Email Verified Successfully",
@@ -57,6 +63,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Security Login Alert",
+                            "Notifies the user when a login occurs from a new device or unrecognized location.",
                             EventType.LoginAlert,
                             channel,
                             "New Login Detected",
@@ -66,6 +74,8 @@ namespace FertileNotify.Infrastructure.Persistence
 
                         // --- E-COMMERCE EVENTS ---
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Order Confirmation",
+                            "Sent after a successful purchase, providing the customer with an order summary.",
                             EventType.OrderCreated,
                             channel,
                             "Order Confirmation #{OrderId}",
@@ -74,6 +84,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Shipping Notification",
+                            "Alerts the customer when their order has been dispatched and provides tracking info.",
                             EventType.OrderShipped,
                             channel,
                             "Your Order Has Shipped! #{OrderId}",
@@ -82,6 +94,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Delivery Confirmation",
+                            "Sent to the customer once the courier marks the package as delivered.",
                             EventType.OrderDelivered,
                             channel,
                             "Order Delivered",
@@ -90,6 +104,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Payment Failure Notice",
+                            "Urgent notification sent when a transaction fails, asking the user to update payment info.",
                             EventType.PaymentFailed,
                             channel,
                             "Payment Failed for Order #{OrderId}",
@@ -99,6 +115,8 @@ namespace FertileNotify.Infrastructure.Persistence
 
                         // --- GENERAL EVENTS ---
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Marketing Campaign",
+                            "A versatile template used for promotional offers, discounts, and announcements.",
                             EventType.Campaign,
                             channel,
                             "{CampaignTitle}",
@@ -107,6 +125,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Monthly Newsletter",
+                            "Sent monthly to keep users informed about platform updates and news.",
                             EventType.MonthlyNewsletter,
                             channel,
                             "{Month} Newsletter",
@@ -115,6 +135,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         ));
 
                         globalTemplates.Add(NotificationTemplate.CreateGlobal(
+                            "Support Ticket Update",
+                            "Notifies the user when there is a new response or status change on their support ticket.",
                             EventType.SupportTicketUpdated,
                             channel,
                             "Update on Ticket #{TicketId}",

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -68,7 +68,10 @@ namespace FertileNotify.Tests
             var subscription = Subscription.Create(subscriberId, SubscriptionPlan.Free);
             _mockSubRepo.Setup(x => x.GetBySubscriberIdAsync(subscriberId)).ReturnsAsync(subscription);
 
-            var template = NotificationTemplate.CreateGlobal(EventType.SubscriberRegistered, NotificationChannel.Email,"Subject {Name}", "Body");
+            string name = "Test Name";
+            string description = "Description";
+
+            var template = NotificationTemplate.CreateGlobal(name, description, EventType.SubscriberRegistered, NotificationChannel.Email,"Subject {Name}", "Body");
             _mockTemplateRepo.Setup(x => x.GetTemplateAsync(EventType.SubscriberRegistered, NotificationChannel.Email, subscriberId)).ReturnsAsync(template);
 
             _mockEmailSender


### PR DESCRIPTION
Introduce Name and Description fields for NotificationTemplate across the stack. Domain: add properties, update constructors, CreateGlobal/CreateCustom factories and Update to validate and set name/description. API: include Name/Description in CreateTemplateRequest, add validation rules, surface fields in TemplatesController responses and include a Source flag (Default/Custom). Persistence: add Name/Description columns and constraints to EF configuration, update migrations and model snapshot. Seed data: provide example names/descriptions for global templates. Tests: updated tests to construct templates with the new parameters.