### PR TITLE
Add template save/edit flows and UI improvements

### DIFF
--- a/frontend/src/api/templateSevice.ts
+++ b/frontend/src/api/templateSevice.ts
@@ -6,7 +6,7 @@ export const templateSevice = {
         const response = await axiosClient.get("templates");
         return response.data;
     },
-    createTemplate: async (data: CreateOrUpdateCustom): Promise<void> => {
+    createOrUpdateTemplate: async (data: CreateOrUpdateCustom): Promise<void> => {
         const response = await axiosClient.post("templates/create-or-update-custom", data);
         return response.data;
     },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -316,7 +316,7 @@ export default function DashboardPage() {
                                             type="text"
                                             className="input-modern flex-1"
                                             onChange={(e) => setProfile({ ...profile, companyName: e.target.value })}
-                                            value={profile.companyName}
+                                            value={profile.companyName || ''}
                                         />
                                         <button
                                             className="btn-primary px-6 disabled:opacity-50"
@@ -336,7 +336,7 @@ export default function DashboardPage() {
                                             type="email"
                                             className="input-modern flex-1"
                                             onChange={(e) => setProfile({ ...profile, email: e.target.value })}
-                                            value={profile.email}
+                                            value={profile.email || ''}
                                         />
                                         <button
                                             className="btn-primary px-6 disabled:opacity-50"
@@ -356,7 +356,7 @@ export default function DashboardPage() {
                                             type="tel"
                                             className="input-modern flex-1"
                                             onChange={(e) => setProfile({ ...profile, phoneNumber: e.target.value })}
-                                            value={profile.phoneNumber}
+                                            value={profile.phoneNumber || ''}
                                         />
                                         <button
                                             className="btn-primary px-6 disabled:opacity-50"

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -1,4 +1,6 @@
 export interface CreateOrUpdateCustom {
+    name:string,
+    description: string,
     eventType: string,
     channel: string,
     subjectTemplate: string,
@@ -16,12 +18,12 @@ export interface Query {
 }
 
 export interface Template {
-    id: string;
+    id: string,
     name: string,
-    description: string
-    event: string;
-    channel: string;
-    subject: string;
-    body: string;
-    source: 'Default' | 'Custom';
+    description: string,
+    event: string,
+    channel: string,
+    subject: string,
+    body: string,
+    source: 'Default' | 'Custom'
 }


### PR DESCRIPTION
Rename template service method to createOrUpdateTemplate and wire it into email visual/advanced editors, SMS editor, and templates page so templates can be prefilled from location state and saved to the API with error handling. Update types (CreateOrUpdateCustom, Template) to include name/description/subject/body fields used by the editors and requests. Enhance TemplatesPage with expandable details, subject/body display, distinction between Default vs Custom templates (read-only defaults), and navigation that passes template state to editors. Fix controlled input issues in DashboardPage by defaulting profile fields to empty strings.