### PR TITLE
Add NotificationLog entity and persistence

### DIFF
--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -6,6 +6,7 @@ using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
 namespace FertileNotify.API.Controllers
@@ -16,10 +17,13 @@ namespace FertileNotify.API.Controllers
     public class TemplatesController : ControllerBase
     {
         private readonly ITemplateRepository _templateRepository;
+        private readonly INotificationLogRepository _logRepository;
 
-        public TemplatesController(ITemplateRepository templateRepository)
+        public TemplatesController(ITemplateRepository templateRepository, INotificationLogRepository logRepository)
         {
+
             _templateRepository = templateRepository;
+            _logRepository = logRepository;
         }
 
         [HttpGet]
@@ -39,6 +43,14 @@ namespace FertileNotify.API.Controllers
                 Body = t.BodyTemplate,
                 Source = t.SubscriberId == null ? "Default" : "Custom"
             }));
+        }
+
+        [HttpGet("logs")]
+        public async Task<IActionResult> GetLogs()
+        {
+            var subscriberId = GetSubscriberIdFromClaims();
+            var logs = await _logRepository.GetLatestBySubscriberIdAsync(subscriberId, 10);
+            return Ok(logs);
         }
 
         [HttpPost("query")]

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -141,6 +141,7 @@ builder.Services.AddScoped<ISubscriberRepository, EfSubscriberRepository>();
 builder.Services.AddScoped<ISubscriptionRepository, EfSubscriptionRepository>();
 builder.Services.AddScoped<ITemplateRepository, EfTemplateRepository>();
 builder.Services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
+builder.Services.AddScoped<INotificationLogRepository, EfNotificationLogRepository>();
 
 // --- BACKGROUND JOBS ---
 builder.Services.AddSingleton<INotificationQueue, InMemoryNotificationQueue>();

--- a/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
@@ -1,0 +1,10 @@
+﻿using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface INotificationLogRepository
+    {
+        Task AddAsync(NotificationLog log);
+        Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count);
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
@@ -1,4 +1,4 @@
-using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 
 namespace FertileNotify.Application.Interfaces
@@ -6,6 +6,6 @@ namespace FertileNotify.Application.Interfaces
     public interface INotificationSender
     {
         NotificationChannel Channel { get; }
-        Task SendAsync(string recipient, string eventType, string payload);
+        Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body);
     }
 }

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -84,7 +84,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
                 command.Recipient
             );
 
-            await sender.SendAsync(command.Recipient, subject, body);
+            await sender.SendAsync(command.SubscriberId, command.Recipient, command.EventType, subject, body);
 
             subscription.IncreaseUsage();
             await _subscriptionRepository.SaveAsync(command.SubscriberId, subscription);

--- a/backend/FertileNotify.Domain/Entities/NotificationLog.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationLog.cs
@@ -1,0 +1,31 @@
+﻿using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+
+namespace FertileNotify.Domain.Entities
+{
+    public class NotificationLog
+    {
+        public Guid Id { get; private set; }
+        public Guid SubscriberId { get; private set; }
+        public string Recipient { get; private set; } = string.Empty;
+        public NotificationChannel Channel { get; private set; } = default!;
+        public EventType EventType { get; private set; } = default!;
+        public string Subject { get; private set; } = string.Empty;
+        public string Body { get; private set; } = string.Empty;
+        public DateTime CreatedAt { get; private set; }
+
+        private NotificationLog() { }
+
+        public NotificationLog(Guid subscriberId, string recipient, NotificationChannel channel, EventType eventType, string subject, string body)
+        {
+            Id = Guid.NewGuid();
+            SubscriberId = subscriberId;
+            Recipient = recipient;
+            Channel = channel;
+            EventType = eventType;
+            Subject = subject;
+            Body = body;
+            CreatedAt = DateTime.UtcNow;
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Authentication/OtpService.cs
+++ b/backend/FertileNotify.Infrastructure/Authentication/OtpService.cs
@@ -1,5 +1,4 @@
 ﻿using FertileNotify.Application.Interfaces;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace FertileNotify.Infrastructure.Authentication

--- a/backend/FertileNotify.Infrastructure/Migrations/20260220113637_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260220113637_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260219083451_InitialCreate")]
+    [Migration("20260220113637_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -58,6 +58,47 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("ApiKeys");
+                });
+
+            modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationLog", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Body")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Channel")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("Recipient")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Subject")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("NotificationLogs");
                 });
 
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationTemplate", b =>

--- a/backend/FertileNotify.Infrastructure/Migrations/20260220113637_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260220113637_InitialCreate.cs
@@ -29,6 +29,24 @@ namespace FertileNotify.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "NotificationLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubscriberId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Recipient = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Channel = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Subject = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "NotificationTemplates",
                 columns: table => new
                 {
@@ -88,6 +106,9 @@ namespace FertileNotify.Infrastructure.Migrations
         {
             migrationBuilder.DropTable(
                 name: "ApiKeys");
+
+            migrationBuilder.DropTable(
+                name: "NotificationLogs");
 
             migrationBuilder.DropTable(
                 name: "NotificationTemplates");

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -57,6 +57,47 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.ToTable("ApiKeys");
                 });
 
+            modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationLog", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Body")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Channel")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("Recipient")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Subject")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("NotificationLogs");
+                });
+
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationTemplate", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
@@ -1,4 +1,6 @@
 ﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -6,24 +8,31 @@ namespace FertileNotify.Infrastructure.Notifications
 {
     public class ConsoleNotificationSender : INotificationSender
     {
+        private readonly INotificationLogRepository _logRepository;
         private readonly ILogger<ConsoleNotificationSender> _logger;
 
-        public ConsoleNotificationSender(ILogger<ConsoleNotificationSender> logger)
+        public ConsoleNotificationSender(INotificationLogRepository logRepository, ILogger<ConsoleNotificationSender> logger)
         {
+            _logRepository = logRepository;
             _logger = logger;
         }
 
         public NotificationChannel Channel => NotificationChannel.Console;
 
-        public Task SendAsync(string recipient, string subject, string body)
+        public async Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
-            _logger.LogInformation(
-                "[CONSOLE] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
+            _logger.LogInformation("[CONSOLE LOG] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+
+            var log = new NotificationLog(
+                subscriberId,
                 recipient,
+                NotificationChannel.Console,
+                eventType,
                 subject,
                 body
             );
-            return Task.CompletedTask;
+
+            await _logRepository.AddAsync(log);
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
@@ -1,4 +1,5 @@
 ﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -15,7 +16,7 @@ namespace FertileNotify.Infrastructure.Notifications
 
         public NotificationChannel Channel => NotificationChannel.Email;
 
-        public Task SendAsync(string recipient, string subject, string body)
+        public Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
             _logger.LogInformation(
                 "[EMAIL] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",

--- a/backend/FertileNotify.Infrastructure/Notifications/SMSNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/SMSNotificationSender.cs
@@ -1,4 +1,5 @@
 ﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -15,7 +16,7 @@ namespace FertileNotify.Infrastructure.Notifications
 
         public NotificationChannel Channel => NotificationChannel.SMS;
 
-        public Task SendAsync(string recipient, string subject, string body)
+        public Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
             _logger.LogInformation(
                 "[SMS] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",

--- a/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -12,6 +12,7 @@ namespace FertileNotify.Infrastructure.Persistence
         public DbSet<Subscription> Subscriptions { get; set; }
         public DbSet<ApiKey> ApiKeys { get; set; }
         public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
+        public DbSet<NotificationLog> NotificationLogs { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationLogConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationLogConfiguration.cs
@@ -1,0 +1,43 @@
+﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FertileNotify.Infrastructure.Persistence.Configurations
+{
+    public class NotificationLogConfiguration : IEntityTypeConfiguration<NotificationLog>
+    {
+        public void Configure(EntityTypeBuilder<NotificationLog> builder)
+        {
+            builder.HasKey(l => l.Id);
+
+            builder.Property(l => l.Recipient)
+                .HasMaxLength(200)
+                .IsRequired();
+
+            builder.Property(t => t.EventType)
+                .HasConversion(
+                    eventType => eventType.Name,
+                    value => EventType.From(value)
+                )
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(t => t.Channel)
+                .HasConversion(
+                    channel => channel.Name,
+                    value => NotificationChannel.From(value)
+                )
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(l => l.Subject)
+                .HasMaxLength(200)
+                .IsRequired();
+
+            builder.Property(l => l.Body)
+                .IsRequired();
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
@@ -1,0 +1,31 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class EfNotificationLogRepository : INotificationLogRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public EfNotificationLogRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddAsync(NotificationLog log)
+        {
+            await _context.Set<NotificationLog>().AddAsync(log);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count)
+        {
+            return await _context.Set<NotificationLog>()
+                .Where(l => l.SubscriberId == subscriberId)
+                .OrderByDescending(l => l.CreatedAt)
+                .Take(count)
+                .ToListAsync();
+        }
+    }
+}

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -75,14 +75,16 @@ namespace FertileNotify.Tests
             _mockTemplateRepo.Setup(x => x.GetTemplateAsync(EventType.SubscriberRegistered, NotificationChannel.Email, subscriberId)).ReturnsAsync(template);
 
             _mockEmailSender
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.SendAsync(subscriberId, "customer@example.com", EventType.SubscriberRegistered, It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
 
             await _handler.HandleAsync(command);
 
             _mockEmailSender.Verify(
                 x => x.SendAsync(
+                    subscriberId,
                     "customer@example.com",
+                    EventType.SubscriberRegistered,
                     It.IsAny<string>(),
                     It.IsAny<string>()
                 ),
@@ -121,7 +123,7 @@ namespace FertileNotify.Tests
             await Assert.ThrowsAsync<BusinessRuleException>(() => _handler.HandleAsync(command));
 
             _mockEmailSender.Verify(
-                x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                x => x.SendAsync(subscriberId, "customer@example.com", EventType.SubscriberRegistered, It.IsAny<string>(), It.IsAny<string>()),
                 Times.Never);
         }
     }


### PR DESCRIPTION
Introduce NotificationLog domain entity, EF configuration, and EfNotificationLogRepository to persist notification history. Register INotificationLogRepository in DI and add DbSet<NotificationLog> to ApplicationDbContext; update migrations to create NotificationLogs table. Expand INotificationSender API to include subscriberId, EventType, subject and body, update ProcessEventHandler and notification sender implementations (Console/Email/SMS) accordingly; Console sender now records logs to the repository. Add a logs endpoint to TemplatesController to fetch recent logs for a subscriber and update tests to match the new sender signature. Also remove an unused MemoryCache using in OtpService.