### PR TITLE
Add frontend Docker, defaults, and Swagger setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,7 @@ REDIS_CONNECTION=redis:6379,abortConnect=false
 
 # --- API Settings ---
 API_PORT=5080
-JWT_SECRET=YOUR_MIN_30_JWT_SECRET_KEY
+JWT_SECRET=FertileNotify_Super_Secret_Key_32_Chars_Long!
+
+# --- Frontend Settings ---
+FRONTEND_PORT=5173

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddRateLimiter(options =>
 });
 
 // --- SWAGGER ---
+builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new() { Title = "Fertile Notify API", Version = "v1" });
@@ -203,16 +204,14 @@ builder.Services.AddScoped<TemplateEngine>();
 
 var app = builder.Build();
 
-// --- MIDDLEWARE PIPELINE ---
-
-if (app.Environment.IsDevelopment())
+// --- SWAGGER ---
+app.UseSwagger();
+app.UseSwaggerUI(c =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI(c =>
-    {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Fertile Notify API v1");
-    });
-}
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Fertile Notify API v1");
+});
+
+// --- MIDDLEWARE PIPELINE ---
 
 // Seeder
 await DbSeeder.SeedAsync(app);

--- a/backend/FertileNotify.API/appsettings.json
+++ b/backend/FertileNotify.API/appsettings.json
@@ -9,20 +9,16 @@
       }
     }
   },
-
   "AllowedHosts": "*",
-
   "JwtSettings": {
-    "SecretKey": "YourSuperSecretKeyHere",
+    "SecretKey": "FertileNotify_Super_Secret_Key_32_Chars_Long!",
     "Issuer": "FertileNotifyAPI",
     "Audience": "FertileNotifyClients",
     "ExpiryInMinutes": 15
   },
-
   "Redis": {
     "ConnectionString": "localhost:6379,abortConnect=false"
   },
-
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=FertileNotifyDb;Username=postgres;Password=mysecretpassword;"
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,42 @@
 version: '3.8'
 
 services:
+  frontend:
+    container_name: fertile-notify-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - VITE_API_URL=http://localhost:${API_PORT:-5080}/api
+    ports:
+      - "${FRONTEND_PORT:-5173}:80"
+    depends_on:
+      - api
+    networks:
+      - fertile-network
+
   api:
     container_name: fertile-notify-api
     build:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "${API_PORT}:8080"
+      - "${API_PORT:-5080}:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
+      - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
+      - Redis__ConnectionString=redis:6379,abortConnect=false
       - JwtSettings__SecretKey=${JWT_SECRET}
+    depends_on:
+      - db
+      - redis
     networks:
       - fertile-network
 
   redis:
     container_name: fertile-notify-redis
     image: redis:7-alpine
-    environment:
-      - Redis__ConnectionString=redis:6379
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
@@ -35,7 +52,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
     ports:
-      - "${DB_PORT}:5432"
+      - "${DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+
+RUN echo 'server { \
+    listen 80; \
+    location / { \
+    root /usr/share/nginx/html; \
+    index index.html index.htm; \
+    try_files $uri $uri/ /index.html; \
+    } \
+    }' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/api/axiosClient.ts
+++ b/frontend/src/api/axiosClient.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosClient = axios.create({
-    baseURL: "http://localhost:5082/api",
+    baseURL: import.meta.env.VITE_API_URL || "http://localhost:5080/api",
     headers: {
         "Content-Type": "application/json",
     },
@@ -27,7 +27,7 @@ axiosClient.interceptors.response.use(
                 if (!refreshToken) {
                     throw new Error("No refresh token available");
                 }
-                const response = await axios.post("http://localhost:5082/api/auth/refresh-token", {
+                const response = await axios.post(`${import.meta.env.VITE_API_URL || "http://localhost:5080/api"}/auth/refresh-token`, {
                     token: refreshToken
                 });
                 const { accessToken, refreshToken: newRefreshToken } = response.data;


### PR DESCRIPTION
Add a frontend Dockerfile and a frontend service to docker-compose (exposes VITE_API_URL and FRONTEND_PORT). Provide sensible defaults for API/DB/Redis ports and add ASPNETCORE_URLS, Redis connection and depends_on in the api service. Update .env.example and appsettings.json to include a JWT secret and FRONTEND_PORT. Enable Swagger explorer and always register Swagger UI in Program.cs (move Swagger setup before middleware and add AddEndpointsApiExplorer). Update frontend axios client to use import.meta.env.VITE_API_URL with a fallback to the API default. Misc: ensure redis_data volume defined and adjust compose build args for the frontend.