### PR TITLE
Add statistics service, API and delivery status

### DIFF
--- a/backend/FertileNotify.API/Controllers/StatisticsController.cs
+++ b/backend/FertileNotify.API/Controllers/StatisticsController.cs
@@ -1,0 +1,44 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace FertileNotify.API.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/statistics")]
+    public class StatisticsController : ControllerBase
+    {
+        private readonly IStatisticsService _statisticsService;
+        private readonly ISubscriptionRepository _subscriptionRepository;
+
+        public StatisticsController(IStatisticsService statisticsService, ISubscriptionRepository subscriptionRepository)
+        {
+            _statisticsService = statisticsService;
+            _subscriptionRepository = subscriptionRepository;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetStats([FromQuery] string period = "daily")
+        {
+            var subscriberId = GetSubscriberIdFromClaims();
+
+            var subscription = await _subscriptionRepository.GetBySubscriberIdAsync(subscriberId)
+                ?? throw new NotFoundException("Subscription not found.");
+
+            var stats = await _statisticsService.GetSubscriberStatsAsync(subscriberId, period, subscription.Plan);
+
+            return Ok(stats);
+        }
+
+        [NonAction]
+        private Guid GetSubscriberIdFromClaims()
+        {
+            var subscriberIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)
+                ?? throw new UnauthorizedException("Subscriber ID claim not found.");
+            return Guid.Parse(subscriberIdClaim.Value);
+        }
+    }
+}

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -144,6 +144,9 @@ builder.Services.AddScoped<ITemplateRepository, EfTemplateRepository>();
 builder.Services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
 builder.Services.AddScoped<INotificationLogRepository, EfNotificationLogRepository>();
 
+// --- NOTIFICATION LOG ---
+builder.Services.AddScoped<IStatisticsService, StatisticsService>();
+
 // --- BACKGROUND JOBS ---
 builder.Services.AddSingleton<INotificationQueue, InMemoryNotificationQueue>();
 builder.Services.AddHostedService<NotificationWorker>();

--- a/backend/FertileNotify.API/appsettings.json
+++ b/backend/FertileNotify.API/appsettings.json
@@ -9,16 +9,20 @@
       }
     }
   },
+
   "AllowedHosts": "*",
+
   "JwtSettings": {
     "SecretKey": "FertileNotify_Super_Secret_Key_32_Chars_Long!",
     "Issuer": "FertileNotifyAPI",
     "Audience": "FertileNotifyClients",
     "ExpiryInMinutes": 15
   },
+
   "Redis": {
     "ConnectionString": "localhost:6379,abortConnect=false"
   },
+
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=FertileNotifyDb;Username=postgres;Password=mysecretpassword;"
   }

--- a/backend/FertileNotify.Application/DTOs/StatisticsDto.cs
+++ b/backend/FertileNotify.Application/DTOs/StatisticsDto.cs
@@ -1,0 +1,11 @@
+﻿namespace FertileNotify.Application.DTOs
+{
+    public class StatisticsDto
+    {
+        public int TotalUsage { get; set; }
+        public int SuccessCount { get; set; }
+        public int FailedCount { get; set; }
+        public Dictionary<string, int> StatsByChannel { get; set; } = new();
+        public Dictionary<string, int> StatsByEventType { get; set; } = new();
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
@@ -6,5 +6,6 @@ namespace FertileNotify.Application.Interfaces
     {
         Task AddAsync(NotificationLog log);
         Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count);
+        Task<List<NotificationLog>> GetLogsForStatsAsync(Guid subscriberId, DateTime startDate);
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationSender.cs
@@ -6,6 +6,6 @@ namespace FertileNotify.Application.Interfaces
     public interface INotificationSender
     {
         NotificationChannel Channel { get; }
-        Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body);
+        Task<bool> SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body);
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/IStatisticsService.cs
+++ b/backend/FertileNotify.Application/Interfaces/IStatisticsService.cs
@@ -1,0 +1,10 @@
+﻿using FertileNotify.Application.DTOs;
+using FertileNotify.Domain.Enums;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface IStatisticsService
+    {
+        Task<StatisticsDto> GetSubscriberStatsAsync(Guid subscriberId, string period, SubscriptionPlan plan);
+    }
+}

--- a/backend/FertileNotify.Application/Services/StatisticsService.cs
+++ b/backend/FertileNotify.Application/Services/StatisticsService.cs
@@ -1,0 +1,55 @@
+﻿using FertileNotify.Application.DTOs;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.Exceptions;
+
+namespace FertileNotify.Application.Services
+{
+    public class StatisticsService : IStatisticsService
+    {
+        private readonly INotificationLogRepository _logRepository;
+
+        public StatisticsService(INotificationLogRepository logRepository)
+        {
+            _logRepository = logRepository;
+        }
+
+        public async Task<StatisticsDto> GetSubscriberStatsAsync(Guid subscriberId, string period, SubscriptionPlan plan)
+        {
+            ValidatePeriodAccess(period, plan);
+
+            DateTime startDate = CalculateStartDate(period);
+
+            var logs = await _logRepository.GetLogsForStatsAsync(subscriberId, startDate);
+
+            return new StatisticsDto
+            {
+                TotalUsage = logs.Count,
+                SuccessCount = logs.Count(l => l.Status == DeliveryStatus.Success),
+                FailedCount = logs.Count(l => l.Status == DeliveryStatus.Failed),
+                StatsByChannel = logs.GroupBy(l => l.Channel).ToDictionary(g => g.Key.Name, g => g.Count()),
+                StatsByEventType = logs.GroupBy(l => l.EventType).ToDictionary(g => g.Key.Name, g => g.Count())
+            };
+        }
+
+        private void ValidatePeriodAccess(string period, SubscriptionPlan plan)
+        {
+            if (plan == SubscriptionPlan.Free && (period != "daily" && period != "weekly"))
+                throw new BusinessRuleException("Free plan only supports daily and weekly statistics.");
+
+            if (plan == SubscriptionPlan.Pro && (period == "6months" || period == "1year"))
+                throw new BusinessRuleException("Pro plan supports up to 3 months of statistics.");
+        }
+
+        private DateTime CalculateStartDate(string period) => period switch
+        {
+            "daily" => DateTime.UtcNow.AddDays(-1),
+            "weekly" => DateTime.UtcNow.AddDays(-7),
+            "1month" => DateTime.UtcNow.AddMonths(-1),
+            "3months" => DateTime.UtcNow.AddMonths(-3),
+            "6months" => DateTime.UtcNow.AddMonths(-6),
+            "1year" => DateTime.UtcNow.AddYears(-1),
+            _ => DateTime.UtcNow.AddDays(-1)
+        };
+    }
+}

--- a/backend/FertileNotify.Domain/Entities/NotificationLog.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationLog.cs
@@ -1,4 +1,5 @@
-﻿using FertileNotify.Domain.Events;
+﻿using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 
 namespace FertileNotify.Domain.Entities
@@ -12,6 +13,8 @@ namespace FertileNotify.Domain.Entities
         public EventType EventType { get; private set; } = default!;
         public string Subject { get; private set; } = string.Empty;
         public string Body { get; private set; } = string.Empty;
+        public DeliveryStatus Status { get; private set; }
+        public string? ErrorMessage { get; private set; }
         public DateTime CreatedAt { get; private set; }
 
         private NotificationLog() { }
@@ -26,6 +29,12 @@ namespace FertileNotify.Domain.Entities
             Subject = subject;
             Body = body;
             CreatedAt = DateTime.UtcNow;
+        }
+
+        public void SetResult(bool isSuccess, string? error = null)
+        {
+            Status = isSuccess ? DeliveryStatus.Success : DeliveryStatus.Failed;
+            ErrorMessage = error;
         }
     }
 }

--- a/backend/FertileNotify.Domain/Enums/DeliveryStatus.cs
+++ b/backend/FertileNotify.Domain/Enums/DeliveryStatus.cs
@@ -1,0 +1,4 @@
+﻿namespace FertileNotify.Domain.Enums
+{
+    public enum DeliveryStatus { Pending, Success, Failed }
+}

--- a/backend/FertileNotify.Infrastructure/Migrations/20260222073819_InitialCreate.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260222073819_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260220113637_InitialCreate")]
+    [Migration("20260222073819_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -78,6 +78,9 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<string>("ErrorMessage")
+                        .HasColumnType("text");
+
                     b.Property<string>("EventType")
                         .IsRequired()
                         .HasMaxLength(50)
@@ -87,6 +90,9 @@ namespace FertileNotify.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("integer");
 
                     b.Property<string>("Subject")
                         .IsRequired()

--- a/backend/FertileNotify.Infrastructure/Migrations/20260222073819_InitialCreate.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260222073819_InitialCreate.cs
@@ -39,6 +39,8 @@ namespace FertileNotify.Infrastructure.Migrations
                     EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     Subject = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     Body = table.Column<string>(type: "text", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "text", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -75,6 +75,9 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<string>("ErrorMessage")
+                        .HasColumnType("text");
+
                     b.Property<string>("EventType")
                         .IsRequired()
                         .HasMaxLength(50)
@@ -84,6 +87,9 @@ namespace FertileNotify.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("integer");
 
                     b.Property<string>("Subject")
                         .IsRequired()

--- a/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
@@ -19,20 +19,26 @@ namespace FertileNotify.Infrastructure.Notifications
 
         public NotificationChannel Channel => NotificationChannel.Console;
 
-        public async Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
+        public async Task<bool> SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
-            _logger.LogInformation("[CONSOLE LOG] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+            try
+            {
+                _logger.LogInformation("[CONSOLE LOG] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
 
-            var log = new NotificationLog(
-                subscriberId,
-                recipient,
-                NotificationChannel.Console,
-                eventType,
-                subject,
-                body
-            );
+                var log = new NotificationLog(
+                    subscriberId,
+                    recipient,
+                    NotificationChannel.Console,
+                    eventType,
+                    subject,
+                    body
+                );
 
-            await _logRepository.AddAsync(log);
+                await _logRepository.AddAsync(log);
+
+                return true;
+            }
+            catch { return false; }
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
@@ -16,15 +16,20 @@ namespace FertileNotify.Infrastructure.Notifications
 
         public NotificationChannel Channel => NotificationChannel.Email;
 
-        public Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
+        public async Task<bool> SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
-            _logger.LogInformation(
-                "[EMAIL] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
-                recipient,
-                subject,
-                body
-            );
-            return Task.CompletedTask;
+            try
+            {
+                _logger.LogInformation(
+                    "[EMAIL] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
+                    recipient,
+                    subject,
+                    body
+                );
+                await Task.Delay( 1 ); // TEST
+                return true;
+            }
+            catch { return false; }
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/SMSNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/SMSNotificationSender.cs
@@ -16,15 +16,20 @@ namespace FertileNotify.Infrastructure.Notifications
 
         public NotificationChannel Channel => NotificationChannel.SMS;
 
-        public Task SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
+        public async Task<bool> SendAsync(Guid subscriberId, string recipient, EventType eventType, string subject, string body)
         {
-            _logger.LogInformation(
-                "[SMS] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
-                recipient,
-                subject,
-                body
-            );
-            return Task.CompletedTask;
+            try
+            {
+                _logger.LogInformation(
+                    "[SMS] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
+                    recipient,
+                    subject,
+                    body
+                );
+                await Task.Delay( 1 ); // TEST
+                return true;
+            }
+            catch { return false; }
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
@@ -27,5 +27,13 @@ namespace FertileNotify.Infrastructure.Persistence
                 .Take(count)
                 .ToListAsync();
         }
+
+        public async Task<List<NotificationLog>> GetLogsForStatsAsync(Guid subscriberId, DateTime startDate)
+        {
+            return await _context.NotificationLogs
+                .Where(l => l.SubscriberId == subscriberId && l.CreatedAt >= startDate)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -75,8 +75,7 @@ namespace FertileNotify.Tests
             _mockTemplateRepo.Setup(x => x.GetTemplateAsync(EventType.SubscriberRegistered, NotificationChannel.Email, subscriberId)).ReturnsAsync(template);
 
             _mockEmailSender
-                .Setup(x => x.SendAsync(subscriberId, "customer@example.com", EventType.SubscriberRegistered, It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.CompletedTask);
+                .Setup(x => x.SendAsync(subscriberId, "customer@example.com", EventType.SubscriberRegistered, It.IsAny<string>(), It.IsAny<string>()));
 
             await _handler.HandleAsync(command);
 


### PR DESCRIPTION
Introduce subscriber statistics: add StatisticsDto, IStatisticsService and StatisticsService (period handling, plan-based access validation, log aggregation). Expose stats via a new authorized StatisticsController and register StatisticsService in DI. Add DeliveryStatus enum and extend NotificationLog with Status, ErrorMessage and SetResult; update repository interfaces and EfNotificationLogRepository with GetLogsForStatsAsync. Change INotificationSender.SendAsync to return bool and update Console/Email/SMS senders to return success flags and catch failures. Update EF migrations/snapshot to include Status and ErrorMessage columns and rename migration; adjust tests to match the new SendAsync signature.