### PR TITLE
Add Cloudflare tunnel & tighten CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ JWT_SECRET=FertileNotify_Super_Secret_Key_32_Chars_Long!
 
 # --- Frontend Settings ---
 FRONTEND_PORT=5173
+
+# --- Cloudflare Settings ---
+TUNNEL_TOKEN=your_cloudflare_tunnel_token_here

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -35,10 +35,13 @@ builder.Host.UseSerilog();
 // --- CORS ---
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowAll", builder =>
-    {
-        builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
-    });
+    options.AddPolicy("AllowFrontend",
+        policy =>
+        {
+            policy.WithOrigins("https://fertile-notify.enesefetokta.shop")
+                  .AllowAnyHeader()
+                  .AllowAnyMethod();
+        });
 });
 
 // --- RATE LIMITER ---
@@ -219,7 +222,7 @@ app.UseSwaggerUI(c =>
 // Seeder
 await DbSeeder.SeedAsync(app);
 
-app.UseCors("AllowAll");
+app.UseCors("AllowFrontend");
 app.UseRateLimiter();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -1,0 +1,11 @@
+tunnel: fertile-tunnel
+credentials-file: /etc/cloudflared/eyJhIjoiNDNlZjE4ZDFjNGMzNDFhN2FhZGUxZjI4MjZkODZlZjQiLCJ0IjoiOTVkNWRhYzktYzFmZC00ZTFkLThlYmQtMGE4NTRmNmFjNDkzIiwicyI6Ik1qQTNOakV6TkRJdE1HTTBZaTAwT0dZMUxUZzBPVGd0T0RNek5UYzJZVGMxTmpKaiJ9.json
+
+ingress:
+  - hostname: fertile-notify.enesefetokta.shop
+    service: http://frontend:80
+
+  - hostname: fertile-notify-api.enesefetokta.shop
+    service: http://api:8080
+
+  - service: http_status:404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        - VITE_API_URL=http://localhost:${API_PORT:-5080}/api
+        - VITE_API_URL=https://fertile-notify-api.enesefetokta.shop/api
     ports:
-      - "${FRONTEND_PORT:-5173}:80"
+      - "3000:80"
     depends_on:
       - api
     networks:
@@ -21,7 +21,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "${API_PORT:-5080}:8080"
+      - "8080:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:8080
@@ -55,6 +55,16 @@ services:
       - "${DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    networks:
+      - fertile-network
+
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    container_name: tunnel
+    restart: unless-stopped
+    command: tunnel run --token ${TUNNEL_TOKEN}
+    depends_on:
+      - api
     networks:
       - fertile-network
 


### PR DESCRIPTION
Add Cloudflare Argo Tunnel configuration and update compose/hosting settings. Created cloudflared/config.yml to route production hostnames to frontend and API, added a cloudflared tunnel service to docker-compose, and added a TUNNEL_TOKEN entry to .env.example. Updated docker-compose to use production hostnames (VITE_API_URL) and adjusted container port mappings for frontend and API. Tightened backend CORS policy in Program.cs to only allow https://fertile-notify.enesefetokta.shop and applied the new policy at startup. Replace the placeholder tunnel token/credentials with real secrets before deployment.