### PR TITLE
Move request models; add ApiResponse

### DIFF
--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.UseCases.ProcessEvent;
 using FertileNotify.Domain.Events;

--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;

--- a/backend/FertileNotify.API/Models/Requests/CreateApiKeyRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/CreateApiKeyRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class CreateApiKeyRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/CreateTemplateRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/CreateTemplateRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class CreateTemplateRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/GetTemplatesRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/GetTemplatesRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class GetTemplatesRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/LoginRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/LoginRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class LoginRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/ManageChannelRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/ManageChannelRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class ManageChannelRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/OtpRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/OtpRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class OtpRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/RefreshTokenRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/RefreshTokenRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class RefreshTokenRequest()
     {

--- a/backend/FertileNotify.API/Models/Requests/RegisterSubscriberRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/RegisterSubscriberRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class RegisterSubscriberRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/SendBulkNotificationRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/SendBulkNotificationRequest.cs
@@ -1,9 +1,11 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
-    public class SendNotificationRequest
+    public class SendBulkNotificationRequest
     {
         public string Channel { get; set; } = "Email";
-        public string Recipient { get; set; } = string.Empty;
+
+        public List<string> Recipients { get; set; } = new();
+
         public string EventType { get; set; } = string.Empty;
         public Dictionary<string, string> Parameters { get; set; } = new();
     }

--- a/backend/FertileNotify.API/Models/Requests/SendNotificationRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/SendNotificationRequest.cs
@@ -1,11 +1,9 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
-    public class SendBulkNotificationRequest
+    public class SendNotificationRequest
     {
         public string Channel { get; set; } = "Email";
-
-        public List<string> Recipients { get; set; } = new();
-
+        public string Recipient { get; set; } = string.Empty;
         public string EventType { get; set; } = string.Empty;
         public Dictionary<string, string> Parameters { get; set; } = new();
     }

--- a/backend/FertileNotify.API/Models/Requests/UpdateCompanyNameRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/UpdateCompanyNameRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class UpdateCompanyNameRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/UpdateContactRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/UpdateContactRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class UpdateContactRequest
     {

--- a/backend/FertileNotify.API/Models/Requests/UpdatePasswordRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/UpdatePasswordRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.API.Models
+﻿namespace FertileNotify.API.Models.Requests
 {
     public class UpdatePasswordRequest
     {

--- a/backend/FertileNotify.API/Models/Responses/ApiResponse.cs
+++ b/backend/FertileNotify.API/Models/Responses/ApiResponse.cs
@@ -1,0 +1,16 @@
+﻿namespace FertileNotify.API.Models.Responses
+{
+    public class ApiResponse<T>
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public T? Data { get; set; }
+        public List<string> Errors { get; set; } = new List<string>();
+
+        public static ApiResponse<T> SuccessResult(T data, string message = default!)
+            => new ApiResponse<T> { Success = true, Data = data, Message = message };
+
+        public static ApiResponse<T> FailureResult(List<string> errors, string message = default!)
+            => new ApiResponse<T> { Success = false, Errors = errors, Message = message };
+    }
+}

--- a/backend/FertileNotify.API/Validators/CreateApiKeyRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateApiKeyRequestValidator.cs
@@ -1,5 +1,5 @@
 ﻿using FluentValidation;
-using FertileNotify.API.Models;
+using FertileNotify.API.Models.Requests;
 
 namespace FertileNotify.API.Validators
 {

--- a/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Domain.ValueObjects;
 using FluentValidation;
 

--- a/backend/FertileNotify.API/Validators/GetTemplatesRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/GetTemplatesRequestValidator.cs
@@ -1,7 +1,7 @@
 ﻿using FluentValidation;
-using FertileNotify.API.Models;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
+using FertileNotify.API.Models.Requests;
 
 namespace FertileNotify.API.Validators
 {

--- a/backend/FertileNotify.API/Validators/LoginRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/LoginRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FluentValidation;
 
 namespace FertileNotify.API.Validators

--- a/backend/FertileNotify.API/Validators/ManageChannelRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ManageChannelRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Domain.ValueObjects;
 using FluentValidation;
 

--- a/backend/FertileNotify.API/Validators/OtpRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/OtpRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FluentValidation;
 
 namespace FertileNotify.API.Validators

--- a/backend/FertileNotify.API/Validators/RefreshTokenRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/RefreshTokenRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FluentValidation;
 
 namespace FertileNotify.API.Validators

--- a/backend/FertileNotify.API/Validators/RegisterSubscriberRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/RegisterSubscriberRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Domain.Enums;
 using FluentValidation;
 using System.Text.RegularExpressions;

--- a/backend/FertileNotify.API/Validators/SendBulkNotificationRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/SendBulkNotificationRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using FluentValidation;

--- a/backend/FertileNotify.API/Validators/SendNotificationRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/SendNotificationRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using FluentValidation;

--- a/backend/FertileNotify.API/Validators/UpdateContactRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/UpdateContactRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FluentValidation;
 using System.Text.RegularExpressions;
 

--- a/backend/FertileNotify.API/Validators/UpdatePasswordRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/UpdatePasswordRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.API.Models;
+﻿using FertileNotify.API.Models.Requests;
 using FluentValidation;
 
 namespace FertileNotify.API.Validators

--- a/backend/FertileNotify.Tests/EmailAddressTests.cs
+++ b/backend/FertileNotify.Tests/EmailAddressTests.cs
@@ -1,7 +1,7 @@
 ﻿using FertileNotify.Domain.ValueObjects;
 using FluentAssertions;
 
-namespace FertileNotify.Tests.Domain
+namespace FertileNotify.Tests
 {
     public class EmailAddressTests
     {


### PR DESCRIPTION
Refactor request DTOs into the FertileNotify.API.Models.Requests namespace (moved files into Models/Requests) and updated controllers/validators to use the new namespace. Added a generic ApiResponse<T> in Models/Responses to standardize API responses. Adjusted test namespace from FertileNotify.Tests.Domain to FertileNotify.Tests. No behavioral changes intended—purely namespace/file organization and response wrapper addition.