### PR TITLE
Normalize controllers to ApiResponse<T> format

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
-using FertileNotify.API.Models;
+using FertileNotify.API.Models.Requests;
+using FertileNotify.API.Models.Responses;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Exceptions;
@@ -38,8 +39,8 @@ namespace FertileNotify.API.Controllers
 
             var otpCode = await _otpService.GenerateOtpAsync(subscriber.Id);
 
-            return Ok(new { Message = "A special 6-character code valid for 5 minutes " +
-                                      "has been sent to your email address. Please enter this code." });
+            return Ok(ApiResponse<object>.SuccessResult(default!, "A special 6-character code valid for 5 minutes has been sent to your email address. Please enter this code."));
+
         }
 
         [HttpPost("verify-code")]
@@ -61,7 +62,7 @@ namespace FertileNotify.API.Controllers
             subscriber.SetRefreshToken(refreshToken);
             await _subscriberRepository.SaveAsync(subscriber);
 
-            return Ok( new { AccessToken = accessToken, RefreshToken = refreshToken } );
+            return Ok(ApiResponse<object>.SuccessResult(new { AccessToken = accessToken, RefreshToken = refreshToken }, "Login successful."));
         }
 
         [HttpPost("refresh-token")]
@@ -82,7 +83,7 @@ namespace FertileNotify.API.Controllers
             subscriber.SetRefreshToken(newRefreshToken);
             await _subscriberRepository.SaveAsync(subscriber);
 
-            return Ok(new { AccessToken = newAccessToken, RefreshToken = newRefreshToken });
+            return Ok(ApiResponse<object>.SuccessResult(new { AccessToken = newAccessToken, RefreshToken = newRefreshToken }, "Token refreshed successfully."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -1,4 +1,5 @@
 ﻿using FertileNotify.API.Models.Requests;
+using FertileNotify.API.Models.Responses;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.UseCases.ProcessEvent;
 using FertileNotify.Domain.Events;
@@ -35,7 +36,7 @@ namespace FertileNotify.API.Controllers
             };
 
             await _queue.QueueBackgroundWorkItemAsync(command);
-            return Accepted((new { status = "Queued", message = "The notification has been added to the queue." }));
+            return Accepted(ApiResponse<object>.SuccessResult(new { status = "Queued" }, "The notification has been added to the queue."));
         }
 
         [HttpPost("bulk")]
@@ -57,12 +58,11 @@ namespace FertileNotify.API.Controllers
                 await _queue.QueueBackgroundWorkItemAsync(command);
             }
 
-            return Accepted(new
+            return Accepted(ApiResponse<object>.SuccessResult(new
             {
                 status = "Queued",
-                totalRequested = request.Recipients.Count,
-                message = $"{request.Recipients.Count} notifications have been added to the queue."
-            });
+                totalRequested = request.Recipients.Count
+            }, $"{request.Recipients.Count} notifications have been added to the queue."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Controllers/StatisticsController.cs
+++ b/backend/FertileNotify.API/Controllers/StatisticsController.cs
@@ -1,4 +1,5 @@
-﻿using FertileNotify.Application.Interfaces;
+﻿using FertileNotify.API.Models.Responses;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -30,7 +31,7 @@ namespace FertileNotify.API.Controllers
 
             var stats = await _statisticsService.GetSubscriberStatsAsync(subscriberId, period.ToLower(), subscription.Plan);
 
-            return Ok(stats);
+            return Ok(ApiResponse<object>.SuccessResult(stats, "Statistics retrieved successfully."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -1,4 +1,5 @@
 ﻿using FertileNotify.API.Models.Requests;
+using FertileNotify.API.Models.Responses;
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
@@ -32,7 +33,7 @@ namespace FertileNotify.API.Controllers
             var subscriberId = GetSubscriberIdFromClaims();
             var templates = await _templateRepository.GetAllTemplatesAsync(subscriberId);
 
-            return Ok(templates.Select(t => new
+            var result = templates.Select(t => new
             {
                 Id = t.Id,
                 Name = t.Name,
@@ -42,7 +43,9 @@ namespace FertileNotify.API.Controllers
                 Subject = t.SubjectTemplate,
                 Body = t.BodyTemplate,
                 Source = t.SubscriberId == null ? "Default" : "Custom"
-            }));
+            });
+
+            return Ok(ApiResponse<object>.SuccessResult(result, "Templates retrieved successfully."));
         }
 
         [HttpGet("logs")]
@@ -51,7 +54,7 @@ namespace FertileNotify.API.Controllers
             var subscriberId = GetSubscriberIdFromClaims();
             var logs = await _logRepository.GetLatestBySubscriberIdAsync(subscriberId, 10);
 
-            return Ok(logs.Select(t => new
+            var result = logs.Select(t => new
             {
                 Id = t.Id,
                 Recipient = t.Recipient,
@@ -60,7 +63,9 @@ namespace FertileNotify.API.Controllers
                 Subject = t.Subject,
                 Body = t.Body,
                 CreatedAt = t.CreatedAt
-            }));
+            });
+
+            return Ok(ApiResponse<object>.SuccessResult(result, "Notification logs retrieved successfully."));
         }
 
         [HttpPost("query")]
@@ -81,7 +86,7 @@ namespace FertileNotify.API.Controllers
                     templates.Add(template);
             }
 
-            return Ok(templates.Select(t => new
+            var result = templates.Select(t => new
             {
                 Id = t.Id,
                 Name = t.Name,
@@ -91,7 +96,9 @@ namespace FertileNotify.API.Controllers
                 Subject = t.SubjectTemplate,
                 Body = t.BodyTemplate,
                 Source = t.SubscriberId == null ? "Default" : "Custom"
-            }));
+            });
+
+            return Ok(ApiResponse<object>.SuccessResult(result, "Queried templates retrieved successfully."));
         }
 
         [HttpPost("create-or-update-custom")]
@@ -122,7 +129,7 @@ namespace FertileNotify.API.Controllers
                 await _templateRepository.AddAsync(newTemplate);
             }
 
-            return Ok();
+            return Ok(ApiResponse<object>.SuccessResult(default!, "Template created or updated successfully."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/backend/FertileNotify.API/Middlewares/ExceptionHandlingMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using FertileNotify.API.Models.Responses;
 using FertileNotify.Domain.Exceptions;
 
 namespace FertileNotify.API.Middlewares
@@ -42,21 +43,24 @@ namespace FertileNotify.API.Middlewares
                 _logger.LogError(ex, "Unhandled exception occurred.");
             }
 
-            var errorResponse = new
+            var errorResponse = new ApiResponse<object>
             {
-                Error = new
+                Success = false,
+                Message = message,
+                Data = new
                 {
                     Code = errorCode,
-                    Message = message,
                     Details = details,
-                    traceId = context.TraceIdentifier
-                }
+                    TraceId = context.TraceIdentifier
+                },
+                Errors = new List<string> { message }
             };
 
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = status;
 
-            return context.Response.WriteAsync(JsonSerializer.Serialize(errorResponse));
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            return context.Response.WriteAsync(JsonSerializer.Serialize(errorResponse, options));
         }
     }
 }


### PR DESCRIPTION
Replace ad-hoc anonymous JSON responses with ApiResponse<T>.SuccessResult across controllers (Auth, Notifications, Statistics, Subscribers, Templates) to standardize response shape and include user-friendly messages. Add necessary using statements for Requests/Responses and adjust returned payloads where appropriate (e.g. tokens, queued counts, templates, logs, API keys, subscriber updates). Update ExceptionHandlingMiddleware to emit ApiResponse objects with Success=false, include TraceId and Errors, and serialize using camelCase JSON options for consistent client consumption.