### PR TITLE
Support API wrapper and improve auth errors

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -39,8 +39,9 @@ export default function LoginPage() {
             await authService.login({ email, password });
             setShowOtpForm(true);
             setTimeLeft(300);
-        } catch (err) {
-            setError("Invalid email or password");
+        } catch (err: any) {
+            const message = err.message || (err.errors && err.errors.length > 0 ? err.errors[0] : "Invalid email or password");
+            setError(message);
             console.error("Login error:", err);
         }
     };
@@ -59,8 +60,9 @@ export default function LoginPage() {
             localStorage.setItem("accessToken", response.accessToken);
             localStorage.setItem("refreshToken", response.refreshToken.token);
             navigate("/dashboard");
-        } catch (err) {
-            setError("Invalid OTP code");
+        } catch (err: any) {
+            const message = err.message || (err.errors && err.errors.length > 0 ? err.errors[0] : "Invalid OTP code");
+            setError(message);
             console.error("OTP verification error:", err);
         }
     };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,6 @@
+export interface ApiResponse<T> {
+    success: boolean;
+    message: string;
+    data: T;
+    errors: string[];
+}


### PR DESCRIPTION
Add ApiResponse<T> type and update axios client to unwrap the API response envelope: successful responses return response.data.data, while failures are rejected. Adjust refresh-token request/response handling to use VITE_API_URL (removed local fallback), send refreshToken field, and extract tokens from the enveloped response. Propagate API error payloads (error.success === false) and type AxiosResponse accordingly. Improve LoginPage error handling to surface API-provided messages/errors (typed err as any). New file: frontend/src/types/api.ts.