### PR TITLE
Add channel settings API and enhance senders

### DIFF
--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -30,7 +30,7 @@ namespace FertileNotify.API.Controllers
             {
                 SubscriberId = GetSubscriberIdFromClaims(),
                 Channel = NotificationChannel.From(request.Channel.Trim().ToLower()),
-                Recipient = request.Recipient.Trim().ToLower(),
+                Recipient = request.Recipient.Trim(),
                 EventType = EventType.From(request.EventType),
                 Parameters = request.Parameters
             };

--- a/backend/FertileNotify.API/Controllers/SubscribersController.cs
+++ b/backend/FertileNotify.API/Controllers/SubscribersController.cs
@@ -187,16 +187,15 @@ namespace FertileNotify.API.Controllers
             return Ok(ApiResponse<object>.SuccessResult(default!, "The subscriber's API Key has been decommissioned."));
         }
 
-        [HttpPost("settings/telegram")]
-        public async Task<IActionResult> SetTelegramSettings([FromBody] string botToken)
+        [HttpPost("settings/channel-setting")]
+        public async Task<IActionResult> SetChannelSetting([FromBody] ChannelSettingRequest request)
         {
             var subscriberId = GetSubscriberIdFromClaims();
-
-            var settings = new Dictionary<string, string> { { "BotToken", botToken } };
-            var channelSetting = new SubscriberChannelSetting(subscriberId, NotificationChannel.Telegram, settings);
+            var channel = NotificationChannel.From(request.Channel);
+            var channelSetting = new SubscriberChannelSetting(subscriberId, channel, request.Settings);
 
             await _subscriberChannelRepository.SaveAsync(channelSetting);
-            return Ok(new { message = "Telegram bot configured successfully." });
+            return Ok(new { message = $"{channel} configured successfully." });
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Models/Requests/ChannelSettingRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/ChannelSettingRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace FertileNotify.API.Models.Requests
+{
+    public class ChannelSettingRequest
+    {
+        public string Channel { get; set; } = null!;
+        public Dictionary<string, string> Settings { get; set; } = new();
+    }
+}

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -19,6 +19,7 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
+using Mjml.Net;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -204,17 +205,18 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
-builder.Services.AddScoped<INotificationSender, DiscordNotificationSender>();
 builder.Services.AddScoped<INotificationSender, WhatsAppNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SignalNotificationSender>();
 
 builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterSubscriberHandler>();
-builder.Services.AddScoped<TemplateEngine>();
+builder.Services.AddScoped<TemplateEngine>(); 
+builder.Services.AddSingleton<IMjmlRenderer, MjmlRenderer>();
 
 // --- HTTP CLIENT ---
 builder.Services.AddHttpClient();
 builder.Services.AddHttpClient<INotificationSender, TelegramNotificationSender>();
+builder.Services.AddHttpClient<INotificationSender, DiscordNotificationSender>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -1,0 +1,32 @@
+﻿using FertileNotify.API.Models.Requests;
+using FertileNotify.Domain.ValueObjects;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class ChannelSettingRequestValidator : AbstractValidator<ChannelSettingRequest>
+    {
+        public ChannelSettingRequestValidator() 
+        {
+            RuleFor(x => x.Channel)
+                .NotEmpty().WithMessage("Channel is a required field.")
+                .Must(ChannelValid).WithMessage("Invalid Channel type.");
+
+            RuleFor(x => x.Settings)
+                .NotEmpty().WithMessage("Settings are required.")
+                .Must(SettingsValid).WithMessage("Invalid settings.");
+        }
+
+        private bool ChannelValid(string channel)
+        {
+            try { NotificationChannel.From(channel); return true; }
+            catch { return false; }
+        }
+
+        private bool SettingsValid(Dictionary<string, string> settings)
+        {
+            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl" };
+            return settings.Keys.All(k => usebleKeys.Contains(k));
+        }
+    }
+}

--- a/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
@@ -36,6 +36,7 @@ namespace FertileNotify.API.Validators
             try { Domain.Events.EventType.From(eventType); return true; }
             catch { return false; }
         }
+
         private bool ChannelValid(string channel)
         {
             try { NotificationChannel.From(channel); return true; }

--- a/backend/FertileNotify.Infrastructure/Notifications/TelegramNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/TelegramNotificationSender.cs
@@ -23,7 +23,7 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                if (providerSettings == null || !providerSettings.TryGetValue("BotToken", out var botToken))
+                if (providerSettings == null || !providerSettings.TryGetValue("TelegramBotToken", out var botToken))
                     return false;
 
                 var url = $"https://api.telegram.org/bot{botToken}/sendMessage";
@@ -37,16 +37,18 @@ namespace FertileNotify.Infrastructure.Notifications
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    var errorDetails = await response.Content.ReadAsStringAsync();
-                    _logger.LogError("Telegram API Error: {Error}", errorDetails);
-                    return false;
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError("Telegram API Error: {Error}", error);
+                    throw new Exception($"Telegram send failed: {response.StatusCode}");
                 }
                 _logger.LogInformation("[TELEGRAM] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
                 return true;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Telegram Exception");
+                _logger.LogError(ex, 
+                    "[TELEGRAM] -> Exception while sending Telegram notification to {Recipient} for subscriber {SubscriberId} and event {EventType}", 
+                    recipient, subscriberId, eventType);
                 return false;
             }
         }


### PR DESCRIPTION
Introduce a generic channel settings flow and harden notification senders.

- API: Add ChannelSettingRequest model and ChannelSettingRequestValidator; replace the Telegram-only settings endpoint with POST settings/channel-setting that accepts channel + settings and saves SubscriberChannelSetting. Trim recipient without lowercasing in NotificationsController.
- DI/Program: Register IMjmlRenderer, adjust TemplateEngine registration, and move DiscordNotificationSender to use typed HttpClient.
- Discord sender: Refactor to use HttpClient, serialize JSON payload to webhook URL (expects DiscordWebhookUrl key), improve logging and error handling and surface failures.
- Telegram sender: Expect TelegramBotToken key (instead of BotToken), throw on non-success responses and improve error logging.
- Validator: Add channel validation helper to template validator and implement allowed settings key checks in ChannelSettingRequestValidator.

These changes enable configuring multiple channel providers per subscriber and make HTTP-based senders more robust and observable.