### PR TITLE
Add Twilio-backed WhatsApp sender and DI

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -205,7 +205,6 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
-builder.Services.AddScoped<INotificationSender, WhatsAppNotificationSender>();
 
 builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterSubscriberHandler>();
@@ -216,6 +215,7 @@ builder.Services.AddSingleton<IMjmlRenderer, MjmlRenderer>();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpClient<INotificationSender, TelegramNotificationSender>();
 builder.Services.AddHttpClient<INotificationSender, DiscordNotificationSender>();
+builder.Services.AddHttpClient<INotificationSender, WhatsAppNotificationSender>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -25,7 +25,7 @@ namespace FertileNotify.API.Validators
 
         private bool SettingsValid(Dictionary<string, string> settings)
         {
-            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl" };
+            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom" };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }
     }

--- a/backend/FertileNotify.Infrastructure/Notifications/WhatsAppNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/WhatsAppNotificationSender.cs
@@ -2,15 +2,19 @@
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
+using System.Text;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
     public class WhatsAppNotificationSender : INotificationSender
     {
-        private readonly ILogger _logger;
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<WhatsAppNotificationSender> _logger;
 
-        public WhatsAppNotificationSender(ILogger<WhatsAppNotificationSender> logger)
+        public WhatsAppNotificationSender(HttpClient httpClient, ILogger<WhatsAppNotificationSender> logger)
         {
+            _httpClient = httpClient;
             _logger = logger;
         }
 
@@ -20,16 +24,45 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                _logger.LogInformation(
-                    "[WhatsApp] Sent to: {Recipient} | Subject: {Subject} | Body: {Body}",
-                    recipient,
-                    subject,
-                    body
-                );
-                await Task.Delay(1); // TEST
+                if (providerSettings == null ||
+                    !providerSettings.TryGetValue("TwilioSid", out var sid) ||
+                    !providerSettings.TryGetValue("TwilioToken", out var token) ||
+                    !providerSettings.TryGetValue("TwilioFrom", out var fromNumber))
+                {
+                    return false;
+                }
+
+                var url = $"https://api.twilio.com/2010-04-01/Accounts/{sid}/Messages.json";
+
+                var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{sid}:{token}"));
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
+
+                var content = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("To", $"whatsapp:{recipient}"),
+                    new KeyValuePair<string, string>("From", $"whatsapp:{fromNumber}"),
+                    new KeyValuePair<string, string>("Body", $"*{subject}*\n{body}")
+                });
+
+                var response = await _httpClient.PostAsync(url, content);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError("[WHATSAPP] Send failed: {Error}", error);
+                    throw new Exception($"WhatsApp send failed: {response.StatusCode}");
+                }
+
+                _logger.LogInformation("[WHATSAPP] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
                 return true;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[WHATSAPP] -> Exception while sending WhatsApp notification to {Recipient} for subscriber {SubscriberId} and event {EventType}",
+                    recipient, subscriberId, eventType);
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Replace direct scoped registration of WhatsAppNotificationSender with AddHttpClient to use IHttpClientFactory. Implement WhatsAppNotificationSender to send messages via Twilio: inject HttpClient, build Basic Auth header, post form-url-encoded payload to Twilio Messages API (To/From/Body with whatsapp: prefix and subject formatting), log success and errors, and return false when required Twilio settings are missing. Update ChannelSettingRequestValidator to accept TwilioSid, TwilioToken and TwilioFrom keys.