### PR TITLE
Add Slack sender and update channel settings

### DIFF
--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -25,7 +25,7 @@ namespace FertileNotify.API.Validators
 
         private bool SettingsValid(Dictionary<string, string> settings)
         {
-            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom" };
+            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom", "SlackAccessToken" };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }
     }

--- a/backend/FertileNotify.Domain/Entities/SubscriberChannelSetting.cs
+++ b/backend/FertileNotify.Domain/Entities/SubscriberChannelSetting.cs
@@ -21,10 +21,7 @@ namespace FertileNotify.Domain.Entities
             foreach (var s in settings) _settings.Add(s.Key, s.Value);
         }
 
-        public void UpdateSettings(Dictionary<string, string> newSettings)
-        {
-            _settings.Clear();
-            foreach (var s in newSettings) _settings.Add(s.Key, s.Value);
-        }
+        public void UpdateSetting(string key, string value)
+            => _settings[key] = value;
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/SlackNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/SlackNotificationSender.cs
@@ -3,17 +3,21 @@ using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
     public class SlackNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
+        private readonly HttpClient _httpClient;
         private readonly ILogger<SlackNotificationSender> _logger;
 
-        public SlackNotificationSender(INotificationLogRepository logRepository, ILogger<SlackNotificationSender> logger)
+        public SlackNotificationSender(HttpClient httpClient, ILogger<SlackNotificationSender> logger)
         {
-            _logRepository = logRepository;
+            _httpClient = httpClient;
             _logger = logger;
         }
 
@@ -23,22 +27,45 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
+                if (providerSettings == null || !providerSettings.TryGetValue("SlackAccessToken", out var token))
+                {
+                    _logger.LogWarning("[SLACK] Access Token not found for subscriber {SubId}", subscriberId);
+                    return false;
+                }
+
+                var url = "https://slack.com/api/chat.postMessage";
+
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                var payload = new
+                {
+                    channel = recipient,
+                    text = $"*Subject:* {subject}\n{body}"
+                };
+
+                var json = JsonSerializer.Serialize(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                var response = await _httpClient.PostAsync(url, content);
+                var responseBody = await response.Content.ReadAsStringAsync();
+
+                using var doc = JsonDocument.Parse(responseBody);
+                if (!doc.RootElement.GetProperty("ok").GetBoolean())
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError("[SLACK] Send failed: {Error}", error);
+                    throw new Exception($"Slack send failed: {response.StatusCode}");
+                }
                 _logger.LogInformation("[SLACK] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
-
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
-
-                await _logRepository.AddAsync(log);
-
                 return true;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[SLACK] -> Exception while sending Slack notification to {Recipient} for subscriber {SubscriberId} and event {EventType}",
+                    recipient, subscriberId, eventType);
+                return false;
+            }
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberChannelRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberChannelRepository.cs
@@ -16,13 +16,16 @@ namespace FertileNotify.Infrastructure.Persistence
 
         public async Task SaveAsync(SubscriberChannelSetting setting)
         {
-            var existing = await _context.SubscriberChannelSettings
+            var existingSetting = await _context.SubscriberChannelSettings
                 .FirstOrDefaultAsync(s => s.SubscriberId == setting.SubscriberId && s.Channel == setting.Channel);
 
-            if (existing != null)
+            if (existingSetting != null)
             {
-                existing.UpdateSettings(setting.Settings as Dictionary<string, string> ?? default!);
-                _context.SubscriberChannelSettings.Update(existing);
+                foreach (var keyValuePair in setting.Settings)
+                {
+                    existingSetting.UpdateSetting(keyValuePair.Key, keyValuePair.Value);
+                }
+                _context.SubscriberChannelSettings.Update(existingSetting);
             }
             else
             {


### PR DESCRIPTION
Add Slack notification support and refine channel settings handling. Validator now accepts SlackAccessToken as a valid setting key. SubscriberChannelSetting exposes UpdateSetting(key, value) for single-key updates instead of replacing the whole dictionary. EfSubscriberChannelRepository.SaveAsync now merges incoming setting key/values into existing entity rather than clearing and replacing. SlackNotificationSender was implemented to use HttpClient to POST to Slack API (chat.postMessage) with a Bearer token from provider settings, parse the JSON response's "ok" field, and improve logging and error handling (returns false on failures). Removed prior dependency on a notification log repository in the Slack sender.