### PR TITLE
Use HttpClient for MS Teams + validator key

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -206,7 +206,6 @@ builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
 builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SlackNotificationSender>();
-builder.Services.AddScoped<INotificationSender, MSTeamsNotificationSender>();
 builder.Services.AddScoped<INotificationSender, FirebasePushNotificationSender>();
 builder.Services.AddScoped<INotificationSender, WebPushNotificationSender>();
 builder.Services.AddScoped<INotificationSender, WebhookNotificationSender>();
@@ -221,6 +220,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddHttpClient<INotificationSender, TelegramNotificationSender>();
 builder.Services.AddHttpClient<INotificationSender, DiscordNotificationSender>();
 builder.Services.AddHttpClient<INotificationSender, WhatsAppNotificationSender>();
+builder.Services.AddHttpClient<INotificationSender, MSTeamsNotificationSender>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -25,7 +25,7 @@ namespace FertileNotify.API.Validators
 
         private bool SettingsValid(Dictionary<string, string> settings)
         {
-            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom", "SlackAccessToken" };
+            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom", "SlackAccessToken", "MSTeamsWebhookUrl" };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }
     }

--- a/backend/FertileNotify.Infrastructure/Notifications/MSTeamsNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/MSTeamsNotificationSender.cs
@@ -1,19 +1,20 @@
 ﻿using FertileNotify.Application.Interfaces;
-using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Text.Json;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
     public class MSTeamsNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
+        private readonly HttpClient _httpClient;
         private readonly ILogger<MSTeamsNotificationSender> _logger;
 
-        public MSTeamsNotificationSender(INotificationLogRepository logRepository, ILogger<MSTeamsNotificationSender> logger)
+        public MSTeamsNotificationSender(HttpClient httpClient, ILogger<MSTeamsNotificationSender> logger)
         {
-            _logRepository = logRepository;
+            _httpClient = httpClient;
             _logger = logger;
         }
 
@@ -23,22 +24,38 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                _logger.LogInformation("[MS TEAMS] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+                if (providerSettings == null || !providerSettings.TryGetValue("MSTeamsWebhookUrl", out var url))
+                {
+                    _logger.LogWarning("[MSTEAMS] Webhook URL not found for subscriber {SubId}", subscriberId);
+                    return false;
+                }
 
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
+                var payload = new
+                {
+                    text = $"### {subject}\n\n{body}"
+                };
 
-                await _logRepository.AddAsync(log);
+                var json = JsonSerializer.Serialize(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
 
+                var response = await _httpClient.PostAsync(url, content);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError("[MSTEAMS] Send failed: {Error}", error);
+                    throw new Exception($"MS Teams send failed: {response.StatusCode}");
+                }
+                _logger.LogInformation("[MSTEAMS] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
                 return true;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[MSTEAMS] -> Exception while sending Microsoft Teams notification to {Recipient} for subscriber {SubscriberId} and event {EventType}",
+                    recipient, subscriberId, eventType);
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Switch MSTeamsNotificationSender to use HttpClient (registered via AddHttpClient) and send JSON webhook payloads to MSTeamsWebhookUrl from provider settings. Remove dependency on NotificationLogRepository, add structured logging and error handling for failed requests. Also update ChannelSettingRequestValidator to allow the "MSTeamsWebhookUrl" key.