### PR TITLE
Add Firebase push notification sender

### DIFF
--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -25,7 +25,12 @@ namespace FertileNotify.API.Validators
 
         private bool SettingsValid(Dictionary<string, string> settings)
         {
-            var usebleKeys = new[] { "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", "TwilioToken", "TwilioFrom", "SlackAccessToken", "MSTeamsWebhookUrl" };
+            var usebleKeys = new[] 
+            { 
+                "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", 
+                "TwilioToken", "TwilioFrom", "SlackAccessToken", 
+                "MSTeamsWebhookUrl", "FirebaseServiceAccountJson" 
+            };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }
     }

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/FertileNotify.Infrastructure/Notifications/FirebasePushNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/FirebasePushNotificationSender.cs
@@ -1,19 +1,19 @@
 ﻿using FertileNotify.Application.Interfaces;
-using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
 using Microsoft.Extensions.Logging;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
     public class FirebasePushNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
         private readonly ILogger<FirebasePushNotificationSender> _logger;
 
-        public FirebasePushNotificationSender(INotificationLogRepository logRepository, ILogger<FirebasePushNotificationSender> logger)
+        public FirebasePushNotificationSender(ILogger<FirebasePushNotificationSender> logger)
         {
-            _logRepository = logRepository;
             _logger = logger;
         }
 
@@ -23,22 +23,56 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                _logger.LogInformation("[FIREBASE PUSH] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+                if (providerSettings == null || !providerSettings.TryGetValue("FirebaseServiceAccountJson", out var jsonKey))
+                {
+                    _logger.LogWarning("[FIREBASE] Access Token not found for subscriber {SubId}", subscriberId);
+                    return false;
+                }
 
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
+                var appName = subscriberId.ToString();
+                FirebaseApp app;
 
-                await _logRepository.AddAsync(log);
+                if (FirebaseApp.GetInstance(appName) == null)
+                {
+                    app = FirebaseApp.Create(new AppOptions()
+                    {
+                        Credential = GoogleCredential.FromJson(jsonKey)
+                    }, appName);
+                }
+                else
+                {
+                    app = FirebaseApp.GetInstance(appName);
+                }
 
+                var messaging = FirebaseMessaging.GetMessaging(app);
+
+                var message = new Message()
+                {
+                    Token = recipient,
+                    Notification = new Notification()
+                    {
+                        Title = subject,
+                        Body = body
+                    },
+                    Data = new Dictionary<string, string>()
+                    {
+                        { "eventType", eventType.Name }
+                    }
+                };
+
+                var result = await messaging.SendAsync(message);
+                Console.WriteLine(result + "");
+
+                _logger.LogInformation("[FIREBASE] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
                 return true;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[FIREBASE] -> Exception while sending Firebase Push notification to {Recipient} for subscriber {SubscriberId} and event {EventType}",
+                    recipient, subscriberId, eventType);
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Introduce Firebase push notifications support: add FirebaseAdmin package reference, extend allowed channel settings with FirebaseServiceAccountJson, and implement FirebasePushNotificationSender using FirebaseAdmin.Messaging. The sender now reads the service account JSON from provider settings, creates or reuses a FirebaseApp per subscriber, builds and sends a Message, and adds improved logging and error handling. Also remove the unused NotificationLogRepository dependency from the sender constructor.