### PR TITLE
Implement WebPush & Webhook senders; update DI/keys

### DIFF
--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -208,7 +208,6 @@ builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
 builder.Services.AddScoped<INotificationSender, SlackNotificationSender>();
 builder.Services.AddScoped<INotificationSender, FirebasePushNotificationSender>();
 builder.Services.AddScoped<INotificationSender, WebPushNotificationSender>();
-builder.Services.AddScoped<INotificationSender, WebhookNotificationSender>();
 
 builder.Services.AddScoped<ProcessEventHandler>();
 builder.Services.AddScoped<RegisterSubscriberHandler>();
@@ -221,6 +220,7 @@ builder.Services.AddHttpClient<INotificationSender, TelegramNotificationSender>(
 builder.Services.AddHttpClient<INotificationSender, DiscordNotificationSender>();
 builder.Services.AddHttpClient<INotificationSender, WhatsAppNotificationSender>();
 builder.Services.AddHttpClient<INotificationSender, MSTeamsNotificationSender>();
+builder.Services.AddHttpClient<INotificationSender, WebhookNotificationSender>();
 
 var app = builder.Build();
 

--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -27,9 +27,12 @@ namespace FertileNotify.API.Validators
         {
             var usebleKeys = new[] 
             { 
-                "TelegramBotToken", "DiscordWebhookUrl", "TwilioSid", 
-                "TwilioToken", "TwilioFrom", "SlackAccessToken", 
-                "MSTeamsWebhookUrl", "FirebaseServiceAccountJson" 
+                "Telegram_BotToken", "Discord_WebhookUrl", "WhatsApp_TwilioSid",
+                "WhatsApp_TwilioToken", "WhatsApp_TwilioFrom", "Slack_AccessToken", 
+                "MSTeams_WebhookUrl", "Firebase_ServiceAccountJson",
+                "WebPush_VapidPublicKey", "WebPush_VapidPrivateKey",
+                "WebPush_OwnerEmail", "WebPush_Icon", "WebPush_WebUrl",
+                "Webhook_Secret"
             };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
+    <PackageReference Include="WebPush" Version="1.0.12" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/backend/FertileNotify.Infrastructure/Notifications/WebPushNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/WebPushNotificationSender.cs
@@ -1,19 +1,18 @@
 ﻿using FertileNotify.Application.Interfaces;
-using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using WebPush;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
     public class WebPushNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
         private readonly ILogger<WebPushNotificationSender> _logger;
 
-        public WebPushNotificationSender(INotificationLogRepository logRepository, ILogger<WebPushNotificationSender> logger)
+        public WebPushNotificationSender(ILogger<WebPushNotificationSender> logger)
         {
-            _logRepository = logRepository;
             _logger = logger;
         }
 
@@ -23,22 +22,58 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                _logger.LogInformation("[WEB PUSH] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+                if (providerSettings == null ||
+                    !providerSettings.TryGetValue("WebPush_VapidPublicKey", out var publicKey) ||
+                    !providerSettings.TryGetValue("WebPush_VapidPrivateKey", out var privateKey) ||
+                    !providerSettings.TryGetValue("WebPush_OwnerEmail", out var ownerEmail) ||
+                    !providerSettings.TryGetValue("WebPush_Icon", out var icon) ||
+                    !providerSettings.TryGetValue("WebPush_WebUrl", out var url))
+                {
+                    _logger.LogWarning("[WEB PUSH] VAPID keys not found for subscriber {SubId}", subscriberId);
+                    return false;
+                }
 
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
+                using var doc = JsonDocument.Parse(recipient);
+                var root = doc.RootElement;
 
-                await _logRepository.AddAsync(log);
+                var endpoint = root.GetProperty("endpoint").GetString();
+                var p256dh = root.GetProperty("keys").GetProperty("p256dh").GetString();
+                var auth = root.GetProperty("keys").GetProperty("auth").GetString();
 
+                if (string.IsNullOrEmpty(endpoint) || string.IsNullOrEmpty(p256dh) || string.IsNullOrEmpty(auth))
+                {
+                    _logger.LogError("[WEB PUSH] Invalid subscription format.");
+                    return false;
+                }
+
+                var subscription = new PushSubscription(endpoint, p256dh, auth);
+
+                var vapidDetails = new VapidDetails($"mailto:{ownerEmail}", publicKey, privateKey);
+
+                var payloadJson = JsonSerializer.Serialize(new
+                {
+                    title = subject,
+                    message = body,
+                    icon,
+                    url
+                });
+
+                var webPushClient = new WebPushClient();
+                await webPushClient.SendNotificationAsync(subscription, payloadJson, vapidDetails);
+
+                _logger.LogInformation("[WEB PUSH] Sent successfully to Subscriber: {SubId}", subscriberId);
                 return true;
             }
-            catch { return false; }
+            catch (WebPushException ex)
+            {
+                _logger.LogError(ex, "[WEB PUSH] Push failed. Status: {Status}", ex.StatusCode);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[WEB PUSH] Unexpected error in WebPushNotificationSender");
+                return false;
+            }
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Notifications/WebhookNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/WebhookNotificationSender.cs
@@ -1,5 +1,7 @@
-﻿using FertileNotify.Application.Interfaces;
-using FertileNotify.Domain.Entities;
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
@@ -8,12 +10,12 @@ namespace FertileNotify.Infrastructure.Notifications
 {
     public class WebhookNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
+        private readonly HttpClient _httpClient;
         private readonly ILogger<WebhookNotificationSender> _logger;
 
-        public WebhookNotificationSender(INotificationLogRepository logRepository, ILogger<WebhookNotificationSender> logger)
+        public WebhookNotificationSender(HttpClient httpClient, ILogger<WebhookNotificationSender> logger)
         {
-            _logRepository = logRepository;
+            _httpClient = httpClient;
             _logger = logger;
         }
 
@@ -23,22 +25,59 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                _logger.LogInformation("[WEB HOOK] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
+                if (string.IsNullOrEmpty(recipient) || !Uri.IsWellFormedUriString(recipient, UriKind.Absolute))
+                {
+                    _logger.LogWarning("[WEBHOOK] Invalid URL for subscriber {SubId}: {Url}", subscriberId, recipient);
+                    return false;
+                }
 
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
+                var payload = new
+                {
+                    id = Guid.NewGuid(),
+                    subscriber_id = subscriberId,
+                    event_type = eventType.Name,
+                    subject = subject,
+                    message = body,
+                    timestamp = DateTime.UtcNow
+                };
 
-                await _logRepository.AddAsync(log);
+                var jsonPayload = JsonSerializer.Serialize(payload);
+                var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
 
-                return true;
+                if (providerSettings != null && providerSettings.TryGetValue("Webhook_Secret", out var secret))
+                {
+                    var signature = GenerateSignature(jsonPayload, secret);
+                    _httpClient.DefaultRequestHeaders.Remove("X-Fertile-Signature");
+                    _httpClient.DefaultRequestHeaders.Add("X-Fertile-Signature", signature);
+                }
+
+                _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("FertileNotify-Webhook/1.0");
+
+                var response = await _httpClient.PostAsync(recipient, content);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogInformation("[WEBHOOK] Successfully sent to {Url}", recipient);
+                    return true;
+                }
+
+                _logger.LogWarning("[WEBHOOK] Failed to send to {Url}. Status: {Status}", recipient, response.StatusCode);
+                return false;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[WEBHOOK] Unexpected error sending to {Url}", recipient);
+                return false;
+            }
+        }
+
+        private string GenerateSignature(string payload, string secret)
+        {
+            var keyBytes = Encoding.UTF8.GetBytes(secret);
+            var payloadBytes = Encoding.UTF8.GetBytes(payload);
+            using var hmac = new HMACSHA256(keyBytes);
+            var hash = hmac.ComputeHash(payloadBytes);
+            return BitConverter.ToString(hash).Replace("-", "").ToLower();
         }
     }
 }


### PR DESCRIPTION
Add WebPush support and improve Webhook sender behavior. Key changes:

- Implement WebPushNotificationSender using the WebPush library: parse subscription JSON, build PushSubscription and VAPID details, serialize payload, send via WebPushClient, and add proper error handling/logging. Removed dependency on NotificationLogRepository.
- Implement WebhookNotificationSender to use injected HttpClient (AddHttpClient registration moved to Program.cs), build JSON payload, optionally sign payload with HMAC-SHA256 using provider setting Webhook_Secret (X-Fertile-Signature), set User-Agent, POST to subscriber URL, and handle response status and errors. Removed dependency on NotificationLogRepository.
- Update DI in Program.cs: register WebhookNotificationSender via AddHttpClient and remove previous scoped registration.
- Update ChannelSettingRequestValidator allowed keys to new provider-prefixed names (e.g. WebPush_*, Webhook_Secret, WhatsApp_* etc.).
- Add WebPush package reference (WebPush v1.0.12) to infrastructure project.

These changes centralize HTTP usage for webhooks, add push notification capability, standardize provider setting keys, and improve error handling and logging for notification senders.