### PR TITLE
Add daily stats and integrate IStatsRepository

### DIFF
--- a/backend/FertileNotify.API/Controllers/StatisticsController.cs
+++ b/backend/FertileNotify.API/Controllers/StatisticsController.cs
@@ -24,14 +24,28 @@ namespace FertileNotify.API.Controllers
         [HttpGet]
         public async Task<IActionResult> GetStats([FromQuery] string period = "daily")
         {
+            string normalizedPeriod = period.ToLower();
             var subscriberId = GetSubscriberIdFromClaims();
 
             var subscription = await _subscriptionRepository.GetBySubscriberIdAsync(subscriberId)
                 ?? throw new NotFoundException("Subscription not found.");
 
-            var stats = await _statisticsService.GetSubscriberStatsAsync(subscriberId, period.ToLower(), subscription.Plan);
+            var stats = await _statisticsService.GetSubscriberStatsAsync(subscriberId, normalizedPeriod, subscription.Plan);
 
-            return Ok(ApiResponse<object>.SuccessResult(stats, "Statistics retrieved successfully."));
+            var result = new
+            {
+                UsageStats = stats,
+                SubscriptionSummary = new
+                {
+                    Plan = subscription.Plan.ToString(),
+                    Limit = subscription.MonthlyLimit,
+                    Used = subscription.UsedThisMonth,
+                    Remaining = subscription.MonthlyLimit - subscription.UsedThisMonth,
+                    ExpiresAt = subscription.ExpiresAt
+                }
+            };
+
+            return Ok(ApiResponse<object>.SuccessResult(result, "Statistics retrieved successfully."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -148,6 +148,7 @@ builder.Services.AddScoped<ITemplateRepository, EfTemplateRepository>();
 builder.Services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
 builder.Services.AddScoped<INotificationLogRepository, EfNotificationLogRepository>();
 builder.Services.AddScoped<ISubscriberChannelRepository, EfSubscriberChannelRepository>();
+builder.Services.AddScoped<IStatsRepository, EfStatsRepository>();
 
 // --- NOTIFICATION LOG ---
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();

--- a/backend/FertileNotify.Application/Interfaces/IStatsRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/IStatsRepository.cs
@@ -1,0 +1,12 @@
+﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface IStatsRepository
+    {
+        Task IncrementAsync(Guid subscriberId, NotificationChannel channel, EventType eventType, bool isSuccess);
+        Task<List<SubscriberDailyStats>> GetStatsAsync(Guid subscriberId, DateTime startDate, DateTime endDate);
+    }
+}

--- a/backend/FertileNotify.Application/Services/StatisticsService.cs
+++ b/backend/FertileNotify.Application/Services/StatisticsService.cs
@@ -8,27 +8,39 @@ namespace FertileNotify.Application.Services
     public class StatisticsService : IStatisticsService
     {
         private readonly INotificationLogRepository _logRepository;
+        private readonly IStatsRepository _statsRepository;
 
-        public StatisticsService(INotificationLogRepository logRepository)
+        public StatisticsService(INotificationLogRepository logRepository, IStatsRepository statsRepository)
         {
             _logRepository = logRepository;
+            _statsRepository = statsRepository;
         }
 
         public async Task<StatisticsDto> GetSubscriberStatsAsync(Guid subscriberId, string period, SubscriptionPlan plan)
         {
             ValidatePeriodAccess(period, plan);
-
             DateTime startDate = CalculateStartDate(period);
-
-            var logs = await _logRepository.GetLogsForStatsAsync(subscriberId, startDate);
+            var statsData = await _statsRepository.GetStatsAsync(subscriberId, startDate, DateTime.UtcNow);
 
             return new StatisticsDto
             {
-                TotalUsage = logs.Count,
-                SuccessCount = logs.Count(l => l.Status == DeliveryStatus.Success),
-                FailedCount = logs.Count(l => l.Status == DeliveryStatus.Failed),
-                StatsByChannel = logs.GroupBy(l => l.Channel).ToDictionary(g => g.Key.Name, g => g.Count()),
-                StatsByEventType = logs.GroupBy(l => l.EventType).ToDictionary(g => g.Key.Name, g => g.Count())
+                TotalUsage = statsData.Sum(s => s.SuccessCount + s.FailedCount),
+                SuccessCount = statsData.Sum(s => s.SuccessCount),
+                FailedCount = statsData.Sum(s => s.FailedCount),
+
+                StatsByChannel = statsData
+                    .GroupBy(s => s.Channel)
+                    .ToDictionary(
+                        g => g.Key.Name,
+                        g => g.Sum(s => s.SuccessCount + s.FailedCount)
+                    ),
+
+                StatsByEventType = statsData
+                    .GroupBy(s => s.EventType)
+                    .ToDictionary(
+                        g => g.Key.Name,
+                        g => g.Sum(s => s.SuccessCount + s.FailedCount)
+                    )
             };
         }
 

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -1,6 +1,8 @@
 using FertileNotify.Application.Interfaces;
 using FertileNotify.Application.Services;
+using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Exceptions;
+using FertileNotify.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
 namespace FertileNotify.Application.UseCases.ProcessEvent
@@ -9,10 +11,11 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
     {
         private readonly ISubscriptionRepository _subscriptionRepository;
         private readonly ISubscriberRepository _subscriberRepository;
-        private readonly IEnumerable<INotificationSender> _senders;
         private readonly ITemplateRepository _templateRepository;
         private readonly ISubscriberChannelRepository _subscriberChannelRepository;
-        private readonly TemplateEngine templateEngine;
+        private readonly IEnumerable<INotificationSender> _senders;
+        private readonly TemplateEngine _templateEngine;
+        private readonly IStatsRepository _statsRepository;
         private readonly ILogger<ProcessEventHandler> _logger;
 
         public ProcessEventHandler(
@@ -22,27 +25,44 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
             ITemplateRepository templateRepository,
             ISubscriberChannelRepository subscriberChannelRepository,
             TemplateEngine templateEngine,
-            ILogger<ProcessEventHandler> logger
-        )
+            IStatsRepository statsRepository,
+            ILogger<ProcessEventHandler> logger)
         {
             _subscriptionRepository = subscriptionRepository;
             _subscriberRepository = subscriberRepository;
             _senders = senders;
             _templateRepository = templateRepository;
             _subscriberChannelRepository = subscriberChannelRepository;
-            this.templateEngine = templateEngine;
+            _templateEngine = templateEngine;
+            _statsRepository = statsRepository;
             _logger = logger;
         }
 
         public async Task HandleAsync(ProcessEventCommand command)
         {
-            _logger.LogInformation(
-                "Processing event {EventType} for Subscriber: {SubscriberId}. Channel: {Channel}",
-                command.EventType.Name,
-                command.SubscriberId,
-                command.Channel
-            );
+            _logger.LogInformation("[HANDLING] Event: {Event}, Channel: {Channel}, Sub: {SubId}",
+                command.EventType.Name, command.Channel.Name, command.SubscriberId);
 
+            var (subscriber, subscription) = await GetAndValidateEntities(command);
+
+            var (subject, body) = await PrepareContent(command);
+
+            var sender = GetSender(command.Channel);
+            var channelSetting = await _subscriberChannelRepository.GetSettingAsync(command.SubscriberId, command.Channel);
+
+            bool isSuccess = await sender.SendAsync(
+                command.SubscriberId,
+                command.Recipient,
+                command.EventType,
+                subject,
+                body,
+                channelSetting?.Settings);
+
+            await FinalizeProcess(command, subscription, isSuccess);
+        }
+
+        private async Task<(Subscriber, Subscription)> GetAndValidateEntities(ProcessEventCommand command)
+        {
             var subscriber = await _subscriberRepository.GetByIdAsync(command.SubscriberId)
                 ?? throw new NotFoundException("Subscriber not found");
 
@@ -50,54 +70,59 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
                 ?? throw new NotFoundException("Subscription not found");
 
             if (!subscription.CanHandle(command.EventType))
-                throw new BusinessRuleException($"Subscription plan does not support event type: {command.EventType.Name}");
+                throw new BusinessRuleException($"Plan does not support event: {command.EventType.Name}");
 
             if (!subscriber.ActiveChannels.Contains(command.Channel))
-                throw new BusinessRuleException($"Subscriber is not enabled for channel: {command.Channel}");
+                throw new BusinessRuleException($"Channel {command.Channel.Name} is not enabled for this subscriber.");
 
             subscription.EnsureCanSendNotification();
 
+            return (subscriber, subscription);
+        }
+
+        private async Task<(string Subject, string Body)> PrepareContent(ProcessEventCommand command)
+        {
             var template = await _templateRepository.GetTemplateAsync(command.EventType, command.Channel, command.SubscriberId)
-                ?? throw new NotFoundException($"No template found for {command.EventType.Name} on channel {command.Channel.Name}");
+                ?? throw new NotFoundException($"No template for {command.EventType.Name} on {command.Channel.Name}");
 
-            string subject = command.EventType.Name;
-            string body = string.Join(", ", command.Parameters.Select(kv => $"{kv.Key}: {kv.Value}"));
+            var subject = _templateEngine.Render(template.SubjectTemplate, command.Channel, command.Parameters);
+            var body = _templateEngine.Render(template.BodyTemplate, command.Channel, command.Parameters);
 
-            if (template != null)
-            {
-                var renderedSubject = templateEngine.Render(template.SubjectTemplate, command.Channel, command.Parameters);
-                var renderedBody = templateEngine.Render(template.BodyTemplate, command.Channel, command.Parameters);
+            return (subject, body);
+        }
 
-                if (!string.IsNullOrWhiteSpace(renderedSubject)) subject = renderedSubject;
-                if (!string.IsNullOrWhiteSpace(renderedBody)) body = renderedBody;
-            }
-
-            var channelSetting = await _subscriberChannelRepository.GetSettingAsync(command.SubscriberId, command.Channel);
-
-            var sender = _senders.FirstOrDefault(s => s.Channel.Equals(command.Channel));
-
+        private INotificationSender GetSender(NotificationChannel channel)
+        {
+            var sender = _senders.FirstOrDefault(s => s.Channel.Equals(channel));
             if (sender == null)
             {
-                _logger.LogError("No implementation found for channel: {Channel}", command.Channel);
-                throw new Exception($"System configuration error: No sender found for {command.Channel}");
+                _logger.LogError("Sender not implemented for: {Channel}", channel.Name);
+                throw new Exception($"System Error: No sender for {channel.Name}");
             }
+            return sender;
+        }
 
-            _logger.LogInformation(
-                "Sending notification via {Channel} to Recipient: {Recipient}",
+        private async Task FinalizeProcess(ProcessEventCommand command, Subscription subscription, bool isSuccess)
+        {
+            await _statsRepository.IncrementAsync(
+                command.SubscriberId,
                 command.Channel,
-                command.Recipient
+                command.EventType,
+                isSuccess
             );
 
-            await sender.SendAsync(command.SubscriberId, command.Recipient, command.EventType, subject, body, channelSetting?.Settings);
+            if (isSuccess)
+            {
+                subscription.IncreaseUsage();
+                await _subscriptionRepository.SaveAsync(command.SubscriberId, subscription);
 
-            subscription.IncreaseUsage();
-            await _subscriptionRepository.SaveAsync(command.SubscriberId, subscription);
-
-            _logger.LogInformation(
-                "Notification sent successfully. Used: {Used}/{Limit}",
-                subscription.UsedThisMonth,
-                subscription.MonthlyLimit
-            );
+                _logger.LogInformation("[SUCCESS] Notification processed. Usage: {Used}/{Limit}",
+                    subscription.UsedThisMonth, subscription.MonthlyLimit);
+            }
+            else
+            {
+                _logger.LogWarning("[FAILED] Notification could not be sent to {Recipient}", command.Recipient);
+            }
         }
     }
 }

--- a/backend/FertileNotify.Domain/Entities/SubscriberDailyStats.cs
+++ b/backend/FertileNotify.Domain/Entities/SubscriberDailyStats.cs
@@ -1,0 +1,32 @@
+﻿using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+
+namespace FertileNotify.Domain.Entities
+{
+    public class SubscriberDailyStats
+    {
+        public Guid Id { get; private set; }
+        public Guid SubscriberId { get; private set; }
+        public DateTime Date { get; private set; }
+        public NotificationChannel Channel { get; private set; } = default!;
+        public EventType EventType { get; private set; } = default!;
+        public int SuccessCount { get; private set; }
+        public int FailedCount { get; private set; }
+
+        private SubscriberDailyStats() { }
+
+        public SubscriberDailyStats(Guid subscriberId, NotificationChannel channel, EventType eventType)
+        {
+            Id = Guid.NewGuid();
+            SubscriberId = subscriberId;
+            Date = DateTime.UtcNow.Date;
+            Channel = channel;
+            EventType = eventType;
+            SuccessCount = 0;
+            FailedCount = 0;
+        }
+
+        public void IncreaseSuccess() => SuccessCount++;
+        public void IncreaseFailure() => FailedCount++;
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Migrations/20260307083447_InitialCreation.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260307083447_InitialCreation.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260301090553_InitialCreation")]
+    [Migration("20260307083447_InitialCreation")]
     partial class InitialCreation
     {
         /// <inheritdoc />
@@ -207,6 +207,41 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.HasIndex("SubscriberId", "Channel");
 
                     b.ToTable("SubscriberChannelSettings");
+                });
+
+            modelBuilder.Entity("FertileNotify.Domain.Entities.SubscriberDailyStats", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Channel")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<DateTime>("Date")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("FailedCount")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("SuccessCount")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SubscriberId", "Channel");
+
+                    b.ToTable("DailyStats");
                 });
 
             modelBuilder.Entity("FertileNotify.Domain.Entities.Subscription", b =>

--- a/backend/FertileNotify.Infrastructure/Migrations/20260307083447_InitialCreation.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260307083447_InitialCreation.cs
@@ -29,6 +29,23 @@ namespace FertileNotify.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "DailyStats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubscriberId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Channel = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    SuccessCount = table.Column<int>(type: "integer", nullable: false),
+                    FailedCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailyStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "NotificationLogs",
                 columns: table => new
                 {
@@ -117,6 +134,11 @@ namespace FertileNotify.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "IX_DailyStats_SubscriberId_Channel",
+                table: "DailyStats",
+                columns: new[] { "SubscriberId", "Channel" });
+
+            migrationBuilder.CreateIndex(
                 name: "IX_SubscriberChannelSettings_SubscriberId_Channel",
                 table: "SubscriberChannelSettings",
                 columns: new[] { "SubscriberId", "Channel" });
@@ -127,6 +149,9 @@ namespace FertileNotify.Infrastructure.Migrations
         {
             migrationBuilder.DropTable(
                 name: "ApiKeys");
+
+            migrationBuilder.DropTable(
+                name: "DailyStats");
 
             migrationBuilder.DropTable(
                 name: "NotificationLogs");

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -206,6 +206,41 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.ToTable("SubscriberChannelSettings");
                 });
 
+            modelBuilder.Entity("FertileNotify.Domain.Entities.SubscriberDailyStats", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Channel")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<DateTime>("Date")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("FailedCount")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("SuccessCount")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SubscriberId", "Channel");
+
+                    b.ToTable("DailyStats");
+                });
+
             modelBuilder.Entity("FertileNotify.Domain.Entities.Subscription", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -14,6 +14,7 @@ namespace FertileNotify.Infrastructure.Persistence
         public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
         public DbSet<NotificationLog> NotificationLogs { get; set; }
         public DbSet<SubscriberChannelSetting> SubscriberChannelSettings { get; set; }
+        public DbSet<SubscriberDailyStats> DailyStats { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/StatsConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/StatsConfiguration.cs
@@ -1,0 +1,34 @@
+﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FertileNotify.Infrastructure.Persistence.Configurations
+{
+    public class StatsConfiguration : IEntityTypeConfiguration<SubscriberDailyStats>
+    {
+        public void Configure(EntityTypeBuilder<SubscriberDailyStats> builder)
+        {
+            builder.HasKey(s => s.Id);
+
+            builder.HasIndex(s => new { s.SubscriberId, s.Channel });
+
+            builder.Property(s => s.Channel)
+                .HasConversion(
+                    channel => channel.Name,
+                    value => NotificationChannel.From(value)
+                )
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(t => t.EventType)
+                .HasConversion(
+                    eventType => eventType.Name,
+                    value => EventType.From(value)
+                )
+                .HasMaxLength(50)
+                .IsRequired();
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/EfStatsRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfStatsRepository.cs
@@ -1,0 +1,43 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class EfStatsRepository : IStatsRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public EfStatsRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task IncrementAsync(Guid subscriberId, NotificationChannel channel, EventType eventType, bool isSuccess)
+        {
+            var today = DateTime.UtcNow.Date;
+
+            var stat = await _context.DailyStats.FirstOrDefaultAsync(x =>
+                x.SubscriberId == subscriberId &&
+                x.Date == today &&
+                x.Channel == channel &&
+                x.EventType == eventType);
+
+            if (stat == null)
+            {
+                stat = new SubscriberDailyStats(subscriberId, channel, eventType);
+                await _context.DailyStats.AddAsync(stat);
+            }
+
+            if (isSuccess) stat.IncreaseSuccess();
+            else stat.IncreaseFailure();
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<List<SubscriberDailyStats>> GetStatsAsync(Guid subscriberId, DateTime startDate, DateTime endDate)
+            => await _context.DailyStats.Where(x => x.SubscriberId == subscriberId && x.Date >= startDate && x.Date <= endDate).ToListAsync();
+    }
+}

--- a/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
+++ b/backend/FertileNotify.Tests/ProcessEventHandlerTests.cs
@@ -18,6 +18,7 @@ namespace FertileNotify.Tests
         private readonly Mock<ISubscriberRepository> _mockSubscriberRepo;
         private readonly Mock<ITemplateRepository> _mockTemplateRepo;
         private readonly Mock<ISubscriberChannelRepository> _mockSubscriberChannelRepo;
+        private readonly Mock<IStatsRepository> _mockStatsRepo;
         private readonly Mock<INotificationSender> _mockEmailSender;
         private readonly Mock<ILogger<ProcessEventHandler>> _mockLogger;
         private readonly Mock<IMjmlRenderer> _mockMjmlRenderer;
@@ -31,6 +32,7 @@ namespace FertileNotify.Tests
             _mockSubscriberRepo = new Mock<ISubscriberRepository>();
             _mockTemplateRepo = new Mock<ITemplateRepository>();
             _mockSubscriberChannelRepo = new Mock<ISubscriberChannelRepository>();
+            _mockStatsRepo = new Mock<IStatsRepository>();
             _mockEmailSender = new Mock<INotificationSender>();
             _mockLogger = new Mock<ILogger<ProcessEventHandler>>();
             _mockMjmlRenderer = new Mock<IMjmlRenderer>();
@@ -50,6 +52,7 @@ namespace FertileNotify.Tests
                 _mockTemplateRepo.Object,
                 _mockSubscriberChannelRepo.Object,
                 _templateEngine,
+                _mockStatsRepo.Object,
                 _mockLogger.Object
             );
         }


### PR DESCRIPTION
Introduce persistent daily statistics and wire them into the processing flow. Added SubscriberDailyStats entity, EF configuration (StatsConfiguration), DbSet and migration changes to create the DailyStats table. Implemented EfStatsRepository and IStatsRepository, registered the repository in DI, and updated StatisticsService to aggregate stats from the stats repository instead of scanning logs. Refactored ProcessEventHandler: reorganized flow (validation, template rendering, sender lookup), increment stats via IStatsRepository.IncrementAsync, and update subscription usage only on successful sends. StatisticsController now returns a subscription summary alongside usage stats. Tests updated to provide a mock IStatsRepository.