### PR TITLE
Add MailKit SMTP email sender

### DIFF
--- a/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ChannelSettingRequestValidator.cs
@@ -32,7 +32,8 @@ namespace FertileNotify.API.Validators
                 "MSTeams_WebhookUrl", "Firebase_ServiceAccountJson",
                 "WebPush_VapidPublicKey", "WebPush_VapidPrivateKey",
                 "WebPush_OwnerEmail", "WebPush_Icon", "WebPush_WebUrl",
-                "Webhook_Secret"
+                "Webhook_Secret", "SMTP_Host", "SMTP_Port", "SMTP_Email", 
+                "SMTP_Password", "SMTP_OwnerName"
             };
             return settings.Keys.All(k => usebleKeys.Contains(k));
         }

--- a/backend/FertileNotify.Application/Services/TemplateEngine.cs
+++ b/backend/FertileNotify.Application/Services/TemplateEngine.cs
@@ -17,21 +17,24 @@ namespace FertileNotify.Application.Services
             if (string.IsNullOrEmpty(template)) return string.Empty;
 
             string rendered = template;
+
             if (parameters != null)
             {
                 foreach (var param in parameters)
                 {
-                    rendered = rendered.Replace($"{{{param.Key}}}", param.Value);
+                    rendered = rendered.Replace($"{{{param.Key}}}", param.Value ?? string.Empty);
                 }
             }
 
             if (channel.Equals(NotificationChannel.Email))
             {
-                var result = _mjmlRenderer.Render(rendered);
-                return result.Html;
+                var mjmlResult = _mjmlRenderer.Render(rendered.Trim());
+
+                if (string.IsNullOrEmpty(mjmlResult.Html)) 
+                    return rendered;
+                return mjmlResult.Html;
             }
 
-            // Telegram, Console ve SMS buradan geçer ve değişkenleri dolmuş halde döner.
             return rendered;
         }
     }

--- a/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
+++ b/backend/FertileNotify.Infrastructure/FertileNotify.Infrastructure.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
+    <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/EmailNotificationSender.cs
@@ -1,8 +1,10 @@
 ﻿using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
+using MailKit.Net.Smtp;
+using MailKit.Security;
 using Microsoft.Extensions.Logging;
-using System.Net.Mail;
+using MimeKit;
 
 namespace FertileNotify.Infrastructure.Notifications
 {
@@ -21,25 +23,36 @@ namespace FertileNotify.Infrastructure.Notifications
         {
             try
             {
-                // Connects to the mailpit service inside Docker
-                // When testing locally, use 'localhost', but inside Docker, use 'mailpit'
-                using var client = new SmtpClient("localhost", 1025);
-
-                var mailMessage = new MailMessage
+                if (providerSettings == null ||
+                    !providerSettings.TryGetValue("SMTP_Host", out var host) ||
+                    !providerSettings.TryGetValue("SMTP_Port", out var port) ||
+                    !providerSettings.TryGetValue("SMTP_Email", out var email) ||
+                    !providerSettings.TryGetValue("SMTP_Password", out var password))
                 {
-                    From = new MailAddress("test@fertilenotify.local"),
-                    Subject = subject,
-                    Body = body,
-                    IsBodyHtml = true
-                };
-                mailMessage.To.Add(recipient);
+                    return false;
+                }
 
-                await client.SendMailAsync(mailMessage);
+                var message = new MimeMessage();
+                message.From.Add(new MailboxAddress(providerSettings.GetValueOrDefault("SMTP_OwnerName", "Fertile Notify"), email));
+                message.To.Add(MailboxAddress.Parse(recipient));
+                message.Subject = subject;
+
+                var bodyBuilder = new BodyBuilder { HtmlBody = body };
+                message.Body = bodyBuilder.ToMessageBody();
+
+                using var client = new SmtpClient();
+
+                await client.ConnectAsync(host, int.Parse(port), SecureSocketOptions.StartTls);
+                await client.AuthenticateAsync(email, password.Trim());
+                await client.SendAsync(message);
+                await client.DisconnectAsync(true);
+
+                _logger.LogInformation("[EMAIL] Sent successfully via MailKit to {Recipient}", recipient);
                 return true;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "[MAILPIT ERROR] Connection failed.");
+                _logger.LogError(ex, "[MAILKIT ERROR] Sending failed for {SubId}", subscriberId);
                 return false;
             }
         }


### PR DESCRIPTION
Enable real SMTP email delivery using MailKit and update related pieces:

- Add SMTP config keys to channel settings validator (SMTP_Host, SMTP_Port, SMTP_Email, SMTP_Password, SMTP_OwnerName) so SMTP provider settings are accepted.
- Add MailKit package reference to the Infrastructure project.
- Replace System.Net.Mail implementation with MailKit/MimeKit in EmailNotificationSender: read SMTP settings from providerSettings, build MimeMessage, connect/authenticate with StartTls, send and disconnect; add logging and safer error messages.
- Improve TemplateEngine: tolerate null parameter values when replacing tokens and trim/render MJML output with a fallback to the original rendered string if MJML result is empty.

These changes prepare the app for configurable SMTP delivery and make template rendering more robust.