### PR TITLE
Use AsNoTracking, fix repos; docker & GC tweaks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,9 @@ jobs:
 
             docker-compose --profile prod pull
 
-            docker-compose --profile prod up -d --remove-orphans
+            docker-compose --profile prod down --remove-orphans
+            docker-compose --profile prod up -d
+
             docker image prune -f
 
             echo "✅ Deploy tamamlandı."

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,11 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app
 COPY --from=build /app/publish .
 
+# GC: memory-conserving workstation mode, hard heap cap ~143MB, tiered PGO for hot paths
+ENV DOTNET_GCConserveMemory=7
+ENV DOTNET_GCHeapHardLimit=150000000
+ENV DOTNET_TieredPGO=1
+
 EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "FertileNotify.API.dll"]

--- a/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/ProcessEvent/ProcessEventHandler.cs
@@ -13,7 +13,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
         private readonly ISubscriberRepository _subscriberRepository;
         private readonly ITemplateRepository _templateRepository;
         private readonly ISubscriberChannelRepository _subscriberChannelRepository;
-        private readonly IEnumerable<INotificationSender> _senders;
+        private readonly Dictionary<NotificationChannel, INotificationSender> _senderMap;
         private readonly TemplateEngine _templateEngine;
         private readonly IStatsRepository _statsRepository;
         private readonly ILogger<ProcessEventHandler> _logger;
@@ -30,7 +30,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
         {
             _subscriptionRepository = subscriptionRepository;
             _subscriberRepository = subscriberRepository;
-            _senders = senders;
+            _senderMap = senders.ToDictionary(s => s.Channel);
             _templateRepository = templateRepository;
             _subscriberChannelRepository = subscriberChannelRepository;
             _templateEngine = templateEngine;
@@ -93,8 +93,7 @@ namespace FertileNotify.Application.UseCases.ProcessEvent
 
         private INotificationSender GetSender(NotificationChannel channel)
         {
-            var sender = _senders.FirstOrDefault(s => s.Channel.Equals(channel));
-            if (sender == null)
+            if (!_senderMap.TryGetValue(channel, out var sender))
             {
                 _logger.LogError("Sender not implemented for: {Channel}", channel.Name);
                 throw new Exception($"System Error: No sender for {channel.Name}");

--- a/backend/FertileNotify.Infrastructure/Notifications/FirebasePushNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/FirebasePushNotificationSender.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using FirebaseAdmin;
@@ -61,7 +61,7 @@ namespace FertileNotify.Infrastructure.Notifications
                 };
 
                 var result = await messaging.SendAsync(message);
-                Console.WriteLine(result + "");
+                _logger.LogDebug("[FIREBASE] Message sent, result: {Result}", result);
 
                 _logger.LogInformation("[FIREBASE] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
                 return true;

--- a/backend/FertileNotify.Infrastructure/Persistence/EfApiKeyRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfApiKeyRepository.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,23 +13,20 @@ namespace FertileNotify.Infrastructure.Persistence
             _context = context;
         }
 
-        public Task SaveAsync(ApiKey apiKey)
+        public async Task SaveAsync(ApiKey apiKey)
         {
-            if (!_context.ApiKeys.Local.Any(k => k.Id == apiKey.Id || k.KeyHash == apiKey.KeyHash))
-            {
-                var exists = _context.ApiKeys.Any(k => k.Id == apiKey.Id);
-                if (!exists)
-                    _context.ApiKeys.Add(apiKey);
-                else
-                    _context.ApiKeys.Update(apiKey);
-            }
+            var exists = await _context.ApiKeys.AnyAsync(k => k.Id == apiKey.Id);
+            if (!exists)
+                _context.ApiKeys.Add(apiKey);
+            else
+                _context.ApiKeys.Update(apiKey);
             return _context.SaveChangesAsync();
         }
 
         public async Task<ApiKey?> GetByKeyHashAsync(string keyHash)
-            => await _context.ApiKeys.FirstOrDefaultAsync(k => k.KeyHash == keyHash);
+            => await _context.ApiKeys.AsNoTracking().FirstOrDefaultAsync(k => k.KeyHash == keyHash);
 
         public Task<List<ApiKey>> GetBySubscriberIdAsync(Guid subscriberId)
-            => _context.ApiKeys.Where(k => k.SubscriberId == subscriberId).OrderByDescending(k => k.CreatedAt).ToListAsync();
+            => _context.ApiKeys.AsNoTracking().Where(k => k.SubscriberId == subscriberId).OrderByDescending(k => k.CreatedAt).ToListAsync();
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,6 +22,7 @@ namespace FertileNotify.Infrastructure.Persistence
         public async Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count)
         {
             return await _context.Set<NotificationLog>()
+                .AsNoTracking()
                 .Where(l => l.SubscriberId == subscriberId)
                 .OrderByDescending(l => l.CreatedAt)
                 .Take(count)

--- a/backend/FertileNotify.Infrastructure/Persistence/EfStatsRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfStatsRepository.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
@@ -38,6 +38,9 @@ namespace FertileNotify.Infrastructure.Persistence
         }
 
         public async Task<List<SubscriberDailyStats>> GetStatsAsync(Guid subscriberId, DateTime startDate, DateTime endDate)
-            => await _context.DailyStats.Where(x => x.SubscriberId == subscriberId && x.Date >= startDate && x.Date <= endDate).ToListAsync();
+            => await _context.DailyStats
+                .AsNoTracking()
+                .Where(x => x.SubscriberId == subscriberId && x.Date >= startDate && x.Date <= endDate)
+                .ToListAsync();
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfSubscriberRepository.cs
@@ -16,32 +16,29 @@ namespace FertileNotify.Infrastructure.Persistence
 
         public async Task SaveAsync(Subscriber subscriber)
         {
-            if (!_context.Subscribers.Local.Any(u => u.Id == subscriber.Id || u.CompanyName == subscriber.CompanyName))
-            {
-                var exists = await _context.Subscribers.AnyAsync(u => u.Id == subscriber.Id);
-                if (!exists)
-                    await _context.Subscribers.AddAsync(subscriber);
-                else
-                    _context.Subscribers.Update(subscriber);
-            }
-            
+            var exists = await _context.Subscribers.AnyAsync(u => u.Id == subscriber.Id);
+            if (!exists)
+                await _context.Subscribers.AddAsync(subscriber);
+            else
+                _context.Subscribers.Update(subscriber);
+
             await _context.SaveChangesAsync();
         }
 
         public async Task<Subscriber?> GetByIdAsync(Guid id)
-            => await _context.Subscribers.FirstOrDefaultAsync(u => u.Id == id);
+            => await _context.Subscribers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == id);
 
         public async Task<List<Guid>> GetExistingIdsAsync(List<Guid> ids)
-            => await _context.Subscribers.Where(u => ids.Contains(u.Id)).Select(u => u.Id).ToListAsync();
+            => await _context.Subscribers.AsNoTracking().Where(u => ids.Contains(u.Id)).Select(u => u.Id).ToListAsync();
 
         public async Task<Subscriber?> GetByEmailAsync(EmailAddress email)
-            => await _context.Subscribers.FirstOrDefaultAsync(u => u.Email == email);
+            => await _context.Subscribers.AsNoTracking().FirstOrDefaultAsync(u => u.Email == email);
 
         public async Task<Subscriber?> GetByPhoneNumberAsync(PhoneNumber phoneNumber)
-            => await _context.Subscribers.FirstOrDefaultAsync(u => u.PhoneNumber == phoneNumber);
+            => await _context.Subscribers.AsNoTracking().FirstOrDefaultAsync(u => u.PhoneNumber == phoneNumber);
 
         public async Task<Subscriber?> GetByRefreshTokenAsync(string refreshToken)
-            => await _context.Subscribers.FirstOrDefaultAsync(u => u.RefreshToken!.Token == refreshToken);
+            => await _context.Subscribers.AsNoTracking().FirstOrDefaultAsync(u => u.RefreshToken!.Token == refreshToken);
 
         public async Task<bool> ExistsAsync(Guid id)
             => await _context.Subscribers.AnyAsync(u => u.Id == id);

--- a/backend/FertileNotify.Infrastructure/Persistence/EfSubscriptionRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfSubscriptionRepository.cs
@@ -15,16 +15,13 @@ namespace FertileNotify.Infrastructure.Persistence
 
         public async Task SaveAsync(Guid userId, Subscription subscription)
         {
-            if (!_context.Subscriptions.Local.Any(s => s.Id == subscription.Id))
-            {
-                 var exists = await _context.Subscriptions.AnyAsync(s => s.Id == subscription.Id);
-                 if(!exists) await _context.Subscriptions.AddAsync(subscription);
-                 else _context.Subscriptions.Update(subscription);
-            }
+            var exists = await _context.Subscriptions.AnyAsync(s => s.Id == subscription.Id);
+            if (!exists) await _context.Subscriptions.AddAsync(subscription);
+            else _context.Subscriptions.Update(subscription);
             await _context.SaveChangesAsync();
         }
 
         public async Task<Subscription?> GetBySubscriberIdAsync(Guid subscriberId)
-            => await _context.Subscriptions.FirstOrDefaultAsync(s => s.SubscriberId == subscriberId);
+            => await _context.Subscriptions.AsNoTracking().FirstOrDefaultAsync(s => s.SubscriberId == subscriberId);
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfTemplateRepository.cs
@@ -28,36 +28,37 @@ namespace FertileNotify.Infrastructure.Persistence
             if (subscriberId.HasValue)
             {
                 var customTemplate = await _context.NotificationTemplates
-                    .FirstOrDefaultAsync(t => 
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(t =>
                         t.SubscriberId == subscriberId && t.EventType == eventType && t.Channel == channel);
 
                 if (customTemplate != null) return customTemplate;
             }
 
+            // Bug fix: include channel filter on global fallback to avoid wrong-channel template
             return await _context.NotificationTemplates
-                .FirstOrDefaultAsync(t => t.SubscriberId == null && t.EventType == eventType);
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.SubscriberId == null && t.EventType == eventType && t.Channel == channel);
         }
 
         public async Task<NotificationTemplate?> GetGlobalTemplateAsync(EventType eventType, NotificationChannel channel)
-            => await _context.NotificationTemplates.FirstOrDefaultAsync(t =>
-                    t.SubscriberId == null && t.EventType == eventType && t.Channel == channel);
+            => await _context.NotificationTemplates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.SubscriberId == null && t.EventType == eventType && t.Channel == channel);
 
         public async Task<NotificationTemplate?> GetCustomTemplateAsync(
             EventType eventType, NotificationChannel channel, Guid subscriberId)
-            => await _context.NotificationTemplates.FirstOrDefaultAsync(t =>
-                    t.SubscriberId == subscriberId && t.EventType == eventType && t.Channel == channel);
+            => await _context.NotificationTemplates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.SubscriberId == subscriberId && t.EventType == eventType && t.Channel == channel);
 
         public async Task<List<NotificationTemplate>> GetAllTemplatesAsync(Guid subscriberId)
         {
-            var globalTemplates = await _context.NotificationTemplates
-                .Where(t => t.SubscriberId == null)
+            // Single query instead of two separate roundtrips
+            return await _context.NotificationTemplates
+                .AsNoTracking()
+                .Where(t => t.SubscriberId == null || t.SubscriberId == subscriberId)
                 .ToListAsync();
-
-            var customTemplates = await _context.NotificationTemplates
-                .Where(t => t.SubscriberId == subscriberId)
-                .ToListAsync();
-
-            return globalTemplates.Concat(customTemplates).ToList();
         }
     }
 }


### PR DESCRIPTION
Various performance, correctness and deployment improvements:

- CI: run `docker-compose down` before `up` to ensure clean restart.
- Dockerfile: set DOTNET_GCConserveMemory, DOTNET_GCHeapHardLimit and DOTNET_TieredPGO to reduce memory usage and enable tiered PGO.
- ProcessEventHandler: convert notification senders to a Dictionary keyed by channel for O(1) lookup and more robust sender resolution.
- Firebase sender: replace Console.WriteLine with structured debug log.
- EF repositories: remove Local collection checks, make SaveAsync truly async, use AnyAsync and add AsNoTracking to read queries to avoid unnecessary change tracking and round-trips.
- Template repo: fix global template fallback to include channel (prevent wrong-channel templates) and consolidate queries into a single roundtrip.

These changes improve performance, reduce memory/DB overhead, and fix a template selection bug.