### PR TITLE
Add message priority for notifications

### DIFF
--- a/backend/FertileNotify.API/Controllers/NotificationsController.cs
+++ b/backend/FertileNotify.API/Controllers/NotificationsController.cs
@@ -31,6 +31,7 @@ namespace FertileNotify.API.Controllers
             var subscriberId = GetSubscriberIdFromClaims();
 
             var eventType = EventType.From(request.EventType);
+            byte priority = eventType.GetPriority();
             var parameters = request.Parameters;
 
             int totalQueued = 0;
@@ -47,6 +48,8 @@ namespace FertileNotify.API.Controllers
                         Recipient = recipientAddress,
                         EventType = request.EventType,
                         Parameters = request.Parameters
+                    }, context => {
+                        context.SetPriority(priority);
                     });
                     totalQueued++;
                 }

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -232,7 +232,7 @@ builder.Services.AddMassTransit(x =>
         cfg.ReceiveEndpoint("notification-queue", e => 
         {
             e.PrefetchCount = 16;
-
+            e.EnablePriority(10);
             e.UseMessageRetry(r => r.Intervals(
                 TimeSpan.FromSeconds(5),
                 TimeSpan.FromSeconds(15),

--- a/backend/FertileNotify.Domain/Events/EventType.cs
+++ b/backend/FertileNotify.Domain/Events/EventType.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.Domain.Events
+namespace FertileNotify.Domain.Events
 {
     public sealed class EventType
     {
@@ -54,6 +54,9 @@
                 "MonthlyNewsletter" => MonthlyNewsletter,
                 "SupportTicketUpdated" => SupportTicketUpdated,
 
+                // For Test
+                "TestForDevelop" => TestForDevelop,
+
                 _ => throw new Exception($"Unknown event type: {name}")
             };
         }
@@ -61,5 +64,39 @@
         public override string ToString() => Name;
         public override bool Equals(object? obj) => obj is EventType other && Name == other.Name;
         public override int GetHashCode() => Name.GetHashCode();
+
+        public byte GetPriority()
+        {
+            return Name switch
+            {
+                // Critical Level
+                "SubscriberRegistered" => 10,
+                "PasswordReset" => 10,
+                "AccountLocked" => 9,
+                "PaymentFailed" => 9,
+
+                // Important Level
+                "LoginAlert" => 8,
+                "EmailVerified" => 7,
+                "OrderCreated" => 7,
+                "OrderCancelled" => 6,
+
+                // Normal Level
+                "SubscriptionRenewed" => 5,
+                "OrderShipped" => 5,
+                "SupportTicketUpdated" => 5,
+                "OrderDelivered" => 4,
+
+                // Low Level
+                "Campaign" => 1,
+                "MonthlyNewsletter" => 0,
+
+                // For Test
+                "TestForDevelop" => 10,
+
+                // Default
+                _ => 1
+            };
+        }
     }
 }


### PR DESCRIPTION
Add priority handling for notification messages. EventType.GetPriority() was implemented to map event names to byte priorities (including a TestForDevelop type). NotificationsController now obtains the priority and sets it on the outgoing send context. The MassTransit receive endpoint was configured with EnablePriority(10) so queued messages are processed according to priority. These changes allow prioritized processing of notification events.