### PR TITLE
Refactor Program: extract configs into extensions

### DIFF
--- a/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
+++ b/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
@@ -1,0 +1,55 @@
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Services;
+using FertileNotify.Application.UseCases.ProcessEvent;
+using FertileNotify.Application.UseCases.RegisterSubscriber;
+using FertileNotify.Infrastructure.Notifications;
+using FertileNotify.Infrastructure.Persistence;
+using Mjml.Net;
+
+namespace FertileNotify.API.Extensions;
+
+public static class ApplicationServiceExtension
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        // Repositories
+        services.AddScoped<ISubscriberRepository, EfSubscriberRepository>();
+        services.AddScoped<ISubscriptionRepository, EfSubscriptionRepository>();
+        services.AddScoped<ITemplateRepository, EfTemplateRepository>();
+        services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
+        services.AddScoped<INotificationLogRepository, EfNotificationLogRepository>();
+        services.AddScoped<ISubscriberChannelRepository, EfSubscriberChannelRepository>();
+        services.AddScoped<IStatsRepository, EfStatsRepository>();
+
+        // Application Services
+        services.AddScoped<IStatisticsService, StatisticsService>();
+        services.AddScoped<IEmailService, SmtpEmailService>();
+        services.AddScoped<TemplateEngine>();
+        services.AddSingleton<IMjmlRenderer, MjmlRenderer>();
+        services.AddHttpClient();
+
+        // Use Cases
+        services.AddScoped<ProcessEventHandler>();
+        services.AddScoped<RegisterSubscriberHandler>();
+
+        // Notification Senders
+        services.AddNotificationSenders();
+
+        return services;
+    }
+
+    private static void AddNotificationSenders(this IServiceCollection services)
+    {
+        services.AddScoped<INotificationSender, ConsoleNotificationSender>();
+        services.AddScoped<INotificationSender, EmailNotificationSender>();
+        services.AddScoped<INotificationSender, SMSNotificationSender>();
+        services.AddScoped<INotificationSender, SlackNotificationSender>();
+        services.AddScoped<INotificationSender, FirebasePushNotificationSender>();
+        services.AddScoped<INotificationSender, WebPushNotificationSender>();
+        services.AddScoped<INotificationSender, TelegramNotificationSender>();
+        services.AddScoped<INotificationSender, DiscordNotificationSender>();
+        services.AddScoped<INotificationSender, WhatsAppNotificationSender>();
+        services.AddScoped<INotificationSender, MSTeamsNotificationSender>();
+        services.AddScoped<INotificationSender, WebhookNotificationSender>();
+    }
+}

--- a/backend/FertileNotify.API/Extensions/AuthExtension.cs
+++ b/backend/FertileNotify.API/Extensions/AuthExtension.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using FertileNotify.API.Authentication;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Application.Services;
+using FertileNotify.Infrastructure.Authentication;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FertileNotify.API.Extensions;
+
+public static class AuthExtension
+{
+    public static IServiceCollection AddAuthConfig(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddScoped<ITokenService, JwtTokenService>();
+        services.AddScoped<ApiKeyService>();
+        services.AddScoped<IOtpService, OtpService>();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = "JWT_OR_APIKEY";
+            options.DefaultChallengeScheme = "JWT_OR_APIKEY";
+        })
+        .AddJwtBearer("Bearer", options =>
+        {
+            var jwtSettings = configuration.GetSection("JwtSettings");
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = jwtSettings["Issuer"],
+                ValidAudience = jwtSettings["Audience"],
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings["SecretKey"]!))
+            };
+        })
+        .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>("ApiKey", null)
+        .AddPolicyScheme("JWT_OR_APIKEY", "JWT_OR_APIKEY", options =>
+        {
+            options.ForwardDefaultSelector = context =>
+            {
+                if (context.Request.Headers.ContainsKey("FN-Api-Key"))
+                    return "ApiKey";
+                return "Bearer";
+            };
+        });
+
+        return services;
+    }
+}

--- a/backend/FertileNotify.API/Extensions/EnvExtension.cs
+++ b/backend/FertileNotify.API/Extensions/EnvExtension.cs
@@ -1,0 +1,63 @@
+using DotNetEnv;
+
+namespace FertileNotify.API.Extensions;
+
+public static class EnvExtension
+{
+    public static void AddCustomEnvVariables(this IConfigurationBuilder configuration)
+    {
+        Env.Load();
+
+        var envValues = new Dictionary<string, string?>();
+
+        // JWT Mapping
+        MapEnv(envValues, "JWT_SECRET", "JwtSettings:SecretKey");
+
+        // Database Mapping
+        var dbUser = Environment.GetEnvironmentVariable("DB_USER");
+        var dbPass = Environment.GetEnvironmentVariable("DB_PASS");
+        if (!string.IsNullOrEmpty(dbUser) && !string.IsNullOrEmpty(dbPass))
+        {
+            var dbHost = Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost";
+            var dbPort = Environment.GetEnvironmentVariable("DB_PORT") ?? "5432";
+            var dbName = Environment.GetEnvironmentVariable("DB_NAME") ?? "FertileNotifyDb";
+            envValues["ConnectionStrings:DefaultConnection"] = $"Host={dbHost};Port={dbPort};Database={dbName};Username={dbUser};Password={dbPass};";
+        }
+
+        // Redis Mapping
+        var redisHost = Environment.GetEnvironmentVariable("REDIS_HOST");
+        if (!string.IsNullOrEmpty(redisHost))
+        {
+            var redisPort = Environment.GetEnvironmentVariable("REDIS_PORT") ?? "6379";
+            envValues["Redis:ConnectionString"] = $"{redisHost}:{redisPort},abortConnect=false";
+        }
+
+        // RabbitMQ Mapping
+        MapEnv(envValues, "RABBITMQ_HOST", "RabbitMQ:Host");
+        MapEnv(envValues, "RABBITMQ_USER", "RabbitMQ:Username");
+        MapEnv(envValues, "RABBITMQ_PASS", "RabbitMQ:Password");
+
+        // OTP Mapping
+        MapEnv(envValues, "OTP_LENGTH", "OTPSettings:Length");
+        MapEnv(envValues, "OTP_EXPIRY_IN_MINUTES", "OTPSettings:ExpiryInMinutes");
+
+        // SMTP Mapping
+        MapEnv(envValues, "SYSTEM_SMTP_HOST", "SystemSmtp:Host");
+        MapEnv(envValues, "SYSTEM_SMTP_PORT", "SystemSmtp:Port");
+        MapEnv(envValues, "SYSTEM_SMTP_USER", "SystemSmtp:Username");
+        MapEnv(envValues, "SYSTEM_SMTP_PASS", "SystemSmtp:Password");
+        MapEnv(envValues, "SYSTEM_SMTP_FROM", "SystemSmtp:From");
+        MapEnv(envValues, "SYSTEM_SMTP_DISPLAY_NAME", "SystemSmtp:DisplayName");
+
+        configuration.AddInMemoryCollection(envValues);
+    }
+
+    private static void MapEnv(Dictionary<string, string?> dict, string envKey, string configKey)
+    {
+        var val = Environment.GetEnvironmentVariable(envKey);
+        if (!string.IsNullOrEmpty(val))
+        {
+            dict[configKey] = val;
+        }
+    }
+}

--- a/backend/FertileNotify.API/Extensions/InfrastructureExtension.cs
+++ b/backend/FertileNotify.API/Extensions/InfrastructureExtension.cs
@@ -1,0 +1,56 @@
+using FertileNotify.Infrastructure.BackgroundJobs;
+using FertileNotify.Infrastructure.Persistence;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+
+namespace FertileNotify.API.Extensions;
+
+public static class InfrastructureExtension
+{
+    public static IServiceCollection AddInfrastructureConfig(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Database
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
+
+        // Health Checks
+        services.AddHealthChecks()
+            .AddNpgSql(configuration.GetConnectionString("DefaultConnection")!);
+
+        // Redis
+        services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = configuration["Redis:ConnectionString"] ?? "localhost:6379";
+            options.InstanceName = "FertileNotify_";
+        });
+
+        // MassTransit (RabbitMQ)
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<NotificationConsumer>();
+
+            x.UsingRabbitMq((context, cfg) =>
+            {
+                cfg.Host(configuration["RabbitMQ:Host"], "/", h => 
+                {
+                    h.Username(configuration["RabbitMQ:Username"] ?? "guest");
+                    h.Password(configuration["RabbitMQ:Password"] ?? "guest");
+                });
+
+                cfg.ReceiveEndpoint("notification-queue", e => 
+                {
+                    e.PrefetchCount = 16;
+                    e.EnablePriority(10);
+                    e.UseMessageRetry(r => r.Intervals(
+                        TimeSpan.FromSeconds(5),
+                        TimeSpan.FromSeconds(15),
+                        TimeSpan.FromSeconds(30)));
+
+                    e.ConfigureConsumer<NotificationConsumer>(context);
+                });
+            });
+        });
+
+        return services;
+    }
+}

--- a/backend/FertileNotify.API/Extensions/SwaggerExtension.cs
+++ b/backend/FertileNotify.API/Extensions/SwaggerExtension.cs
@@ -1,0 +1,70 @@
+using Microsoft.OpenApi.Models;
+
+namespace FertileNotify.API.Extensions;
+
+public static class SwaggerExtension
+{
+    public static IServiceCollection AddSwaggerConfig(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new() { Title = "Fertile Notify API", Version = "v1" });
+            c.CustomSchemaIds(type => type.FullName);
+            
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+                Name = "Authorization",
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.ApiKey,
+                Scheme = "Bearer"
+            });
+            
+            c.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
+            {
+                Description = "API Key authentication using FN-Api-Key header. Example: \"FN-Api-Key: your-api-key\"",
+                Name = "FN-Api-Key",
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.ApiKey,
+                Scheme = "ApiKeyScheme"
+            });
+            
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
+                        Scheme = "oauth2",
+                        Name = "Bearer",
+                        In = ParameterLocation.Header,
+                    },
+                    new List<string>()
+                },
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" },
+                        Scheme = "ApiKeyScheme",
+                        Name = "FN-Api-Key",
+                        In = ParameterLocation.Header,
+                    },
+                    new List<string>()
+                }
+            });
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseSwaggerConfig(this IApplicationBuilder app)
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI(c =>
+        {
+            c.SwaggerEndpoint("/swagger/v1/swagger.json", "Fertile Notify API v1");
+        });
+        return app;
+    }
+}

--- a/backend/FertileNotify.API/Extensions/WebExtension.cs
+++ b/backend/FertileNotify.API/Extensions/WebExtension.cs
@@ -1,0 +1,78 @@
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace FertileNotify.API.Extensions;
+
+public static class WebExtension
+{
+    public static IServiceCollection AddWebConfig(this IServiceCollection services)
+    {
+        services.AddControllers()
+            .AddJsonOptions(options =>
+            {
+                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            });
+
+        services.AddFluentValidationAutoValidation();
+        services.AddValidatorsFromAssemblyContaining<Program>();
+
+        services.AddCors(options =>
+        {
+            options.AddPolicy("AllowFrontend", policy =>
+            {
+                var allowedOrigins = Environment.GetEnvironmentVariable("ALLOWED_ORIGINS")?
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    ?? new[] { "http://localhost:3000", "http://localhost:5173" };
+
+                policy.WithOrigins(allowedOrigins)
+                      .AllowAnyHeader()
+                      .AllowAnyMethod()
+                      .AllowCredentials();
+            });
+        });
+
+        services.AddRateLimiter(options =>
+        {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+            {
+                var subscriberId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                var partitionKey = subscriberId ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
+                var plan = context.User.FindFirst("Plan")?.Value ?? "Free";
+
+                int permitLimit = plan switch
+                {
+                    "Pro" => 100,
+                    "Enterprise" => 1000,
+                    _ => 20
+                };
+
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: partitionKey,
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = permitLimit,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    });
+            });
+
+            options.OnRejected = async (context, token) =>
+            {
+                context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                await context.HttpContext.Response.WriteAsync("Too many requests. Please upgrade your plan.", token);
+            };
+        });
+
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+        });
+
+        return services;
+    }
+}

--- a/backend/FertileNotify.API/Program.cs
+++ b/backend/FertileNotify.API/Program.cs
@@ -1,83 +1,13 @@
-using FertileNotify.API.Authentication;
+using FertileNotify.API.Extensions;
 using FertileNotify.API.Middlewares;
-using FertileNotify.Application.Interfaces;
-using FertileNotify.Application.Services;
-using FertileNotify.Application.UseCases.ProcessEvent;
-using FertileNotify.Application.UseCases.RegisterSubscriber;
-using FertileNotify.Infrastructure.Authentication;
-using FertileNotify.Infrastructure.BackgroundJobs;
-using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
-using FluentValidation;
-using FluentValidation.AspNetCore;
-using MassTransit;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
-using Mjml.Net;
 using Serilog;
-using System.Security.Claims;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.RateLimiting;
 
-DotNetEnv.Env.Load();
-
-var envValues = new Dictionary<string, string?>();
-
-// --- JWT Mapping ---
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JWT_SECRET")))
-    envValues["JwtSettings:SecretKey"] = Environment.GetEnvironmentVariable("JWT_SECRET");
-
-// --- Database Mapping ---
-var dbUser = Environment.GetEnvironmentVariable("DB_USER");
-var dbPass = Environment.GetEnvironmentVariable("DB_PASS");
-if (!string.IsNullOrEmpty(dbUser) && !string.IsNullOrEmpty(dbPass))
-{
-    var dbHost = Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost";
-    var dbPort = Environment.GetEnvironmentVariable("DB_PORT") ?? "5432";
-    var dbName = Environment.GetEnvironmentVariable("DB_NAME") ?? "FertileNotifyDb";
-    envValues["ConnectionStrings:DefaultConnection"] = $"Host={dbHost};Port={dbPort};Database={dbName};Username={dbUser};Password={dbPass};";
-}
-
-// --- Redis Mapping ---
-var redisHost = Environment.GetEnvironmentVariable("REDIS_HOST");
-if (!string.IsNullOrEmpty(redisHost))
-{
-    var redisPort = Environment.GetEnvironmentVariable("REDIS_PORT") ?? "6379";
-    envValues["Redis:ConnectionString"] = $"{redisHost}:{redisPort},abortConnect=false";
-}
-
-// --- RabbitMQ Mapping ---
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RABBITMQ_HOST")))
-    envValues["RabbitMQ:Host"] = Environment.GetEnvironmentVariable("RABBITMQ_HOST");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RABBITMQ_USER")))
-    envValues["RabbitMQ:Username"] = Environment.GetEnvironmentVariable("RABBITMQ_USER");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RABBITMQ_PASS")))
-    envValues["RabbitMQ:Password"] = Environment.GetEnvironmentVariable("RABBITMQ_PASS");
-
-// --- OTP Mapping ---
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTP_LENGTH")))
-    envValues["OTPSettings:Length"] = Environment.GetEnvironmentVariable("OTP_LENGTH");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTP_EXPIRY_IN_MINUTES")))
-    envValues["OTPSettings:ExpiryInMinutes"] = Environment.GetEnvironmentVariable("OTP_EXPIRY_IN_MINUTES");
-
-// --- SMTP Mapping ---
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_HOST")))
-    envValues["SystemSmtp:Host"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_HOST");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_PORT")))
-    envValues["SystemSmtp:Port"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_PORT");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_USER")))
-    envValues["SystemSmtp:Username"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_USER");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_PASS")))
-    envValues["SystemSmtp:Password"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_PASS");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_FROM")))
-    envValues["SystemSmtp:From"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_FROM");
-if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_SMTP_DISPLAY_NAME")))
-    envValues["SystemSmtp:DisplayName"] = Environment.GetEnvironmentVariable("SYSTEM_SMTP_DISPLAY_NAME");
-
+// --- INITIALIZATION ---
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddInMemoryCollection(envValues);
+
+// --- CONFIGURATION ---
+builder.Configuration.AddCustomEnvVariables(); // Custom extension
 
 // --- LOGGING ---
 Log.Logger = new LoggerConfiguration()
@@ -89,258 +19,39 @@ Log.Logger = new LoggerConfiguration()
 
 builder.Host.UseSerilog();
 
-// --- CORS ---
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("AllowFrontend", policy =>
-    {
-        var allowedOrigins = Environment.GetEnvironmentVariable("ALLOWED_ORIGINS")?
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            ?? new[] { "http://localhost:3000", "http://localhost:5173" };
-
-        policy.WithOrigins(allowedOrigins)
-              .AllowAnyHeader()
-              .AllowAnyMethod()
-              .AllowCredentials();
-    });
-});
-
-// --- RATE LIMITER ---
-builder.Services.AddRateLimiter(options =>
-{
-    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
-    {
-        var subscriberId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        var partitionKey = subscriberId ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous";
-
-        var plan = context.User.FindFirst("Plan")?.Value ?? "Free";
-
-        int permitLimit = plan switch
-        {
-            "Pro" => 100,
-            "Enterprise" => 1000,
-            _ => 20
-        };
-
-        return RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: partitionKey,
-            factory: _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = permitLimit,
-                Window = TimeSpan.FromMinutes(1),
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                QueueLimit = 0
-            });
-    });
-
-    options.OnRejected = async (context, token) =>
-    {
-        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        await context.HttpContext.Response.WriteAsync("Too many requests. Please upgrade your plan.", token);
-    };
-});
-
-// --- SWAGGER ---
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.SwaggerDoc("v1", new() { Title = "Fertile Notify API", Version = "v1" });
-    c.CustomSchemaIds(type => type.FullName);
-    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
-        Name = "Authorization",
-        In = ParameterLocation.Header,
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = "Bearer"
-    });
-    c.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
-    {
-        Description = "API Key authentication using FN-Api-Key header. Example: \"FN-Api-Key: your-api-key\"",
-        Name = "FN-Api-Key",
-        In = ParameterLocation.Header,
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = "ApiKeyScheme"
-    });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
-                Scheme = "oauth2",
-                Name = "Bearer",
-                In = ParameterLocation.Header,
-            },
-            new List<string>()
-        },
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" },
-                Scheme = "ApiKeyScheme",
-                Name = "FN-Api-Key",
-                In = ParameterLocation.Header,
-            },
-            new List<string>()
-        }
-    });
-});
-
-// --- CONTROLLERS ---
-builder.Services.AddControllers()
-    .AddJsonOptions(options =>
-    {
-        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-    });
-
-// --- DATABASE & EF ---
-builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
-
-builder.Services.AddHealthChecks()
-    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!);
-
-// --- REPOSITORIES ---
-builder.Services.AddScoped<ISubscriberRepository, EfSubscriberRepository>();
-builder.Services.AddScoped<ISubscriptionRepository, EfSubscriptionRepository>();
-builder.Services.AddScoped<ITemplateRepository, EfTemplateRepository>();
-builder.Services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
-builder.Services.AddScoped<INotificationLogRepository, EfNotificationLogRepository>();
-builder.Services.AddScoped<ISubscriberChannelRepository, EfSubscriberChannelRepository>();
-builder.Services.AddScoped<IStatsRepository, EfStatsRepository>();
-
-// --- NOTIFICATION LOG ---
-builder.Services.AddScoped<IStatisticsService, StatisticsService>();
-
-// --- EMAIL ---
-builder.Services.AddScoped<IEmailService, SmtpEmailService>();
-
-// --- BACKGROUND JOBS ---
-builder.Services.AddMassTransit(x =>
-{
-    x.AddConsumer<NotificationConsumer>();
-
-    x.UsingRabbitMq((context, cfg) =>
-    {
-        cfg.Host(builder.Configuration["RabbitMQ:Host"], "/", h => 
-        {
-            h.Username(builder.Configuration["RabbitMQ:Username"] ?? "guest");
-            h.Password(builder.Configuration["RabbitMQ:Password"] ?? "guest");
-        });
-
-        cfg.ReceiveEndpoint("notification-queue", e => 
-        {
-            e.PrefetchCount = 16;
-            e.EnablePriority(10);
-            e.UseMessageRetry(r => r.Intervals(
-                TimeSpan.FromSeconds(5),
-                TimeSpan.FromSeconds(15),
-                TimeSpan.FromSeconds(30)));
-
-            e.ConfigureConsumer<NotificationConsumer>(context);
-        });
-    });
-});
-
-// --- VALIDATION ---
-builder.Services.AddFluentValidationAutoValidation();
-builder.Services.AddValidatorsFromAssemblyContaining<Program>();
-
-// --- AUTH ---
-builder.Services.AddScoped<ITokenService, JwtTokenService>();
-builder.Services.AddScoped<ApiKeyService>();
-builder.Services.AddScoped<IOtpService, OtpService>();
-
-builder.Services.AddStackExchangeRedisCache(options =>
-{
-    options.Configuration = builder.Configuration["Redis:ConnectionString"] ?? "localhost:6379";
-    options.InstanceName = "FertileNotify_";
-});
-
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultScheme = "JWT_OR_APIKEY";
-    options.DefaultChallengeScheme = "JWT_OR_APIKEY";
-})
-.AddJwtBearer("Bearer", options =>
-{
-    var jwtSettings = builder.Configuration.GetSection("JwtSettings");
-    options.TokenValidationParameters = new TokenValidationParameters
-    {
-        ValidateIssuer = true,
-        ValidateAudience = true,
-        ValidateLifetime = true,
-        ValidateIssuerSigningKey = true,
-        ValidIssuer = jwtSettings["Issuer"],
-        ValidAudience = jwtSettings["Audience"],
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings["SecretKey"]!))
-    };
-})
-.AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>("ApiKey", null)
-.AddPolicyScheme("JWT_OR_APIKEY", "JWT_OR_APIKEY", options =>
-{
-    options.ForwardDefaultSelector = context =>
-    {
-        if (context.Request.Headers.ContainsKey("FN-Api-Key"))
-            return "ApiKey";
-        return "Bearer";
-    };
-});
-
-// --- SERVICES ---
-builder.Services.AddHttpClient();
-
-builder.Services.AddScoped<INotificationSender, ConsoleNotificationSender>();
-builder.Services.AddScoped<INotificationSender, EmailNotificationSender>();
-builder.Services.AddScoped<INotificationSender, SMSNotificationSender>();
-builder.Services.AddScoped<INotificationSender, SlackNotificationSender>();
-builder.Services.AddScoped<INotificationSender, FirebasePushNotificationSender>();
-builder.Services.AddScoped<INotificationSender, WebPushNotificationSender>();
-
-builder.Services.AddScoped<ProcessEventHandler>();
-builder.Services.AddScoped<RegisterSubscriberHandler>();
-builder.Services.AddScoped<TemplateEngine>(); 
-builder.Services.AddSingleton<IMjmlRenderer, MjmlRenderer>();
-
-builder.Services.AddScoped<INotificationSender, TelegramNotificationSender>();
-builder.Services.AddScoped<INotificationSender, DiscordNotificationSender>();
-builder.Services.AddScoped<INotificationSender, WhatsAppNotificationSender>();
-builder.Services.AddScoped<INotificationSender, MSTeamsNotificationSender>();
-builder.Services.AddScoped<INotificationSender, WebhookNotificationSender>();
-
-// --- PROXY HEADERS ---
-builder.Services.Configure<ForwardedHeadersOptions>(options =>
-{
-    options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
-});
+// --- SERVICES REGISTRATION ---
+builder.Services
+    .AddWebConfig()             // CORS, Rate Limiting, Controllers, Validation
+    .AddSwaggerConfig()         // Swagger Documentation & Security
+    .AddInfrastructureConfig(builder.Configuration) // DB, Redis, RabbitMQ, HealthChecks
+    .AddAuthConfig(builder.Configuration)           // JWT, ApiKey, Token Services
+    .AddApplicationServices();  // Repositories, Use Cases, Core Services
 
 var app = builder.Build();
 
-app.UseForwardedHeaders();
-
-// --- SWAGGER ---
-app.UseSwagger();
-app.UseSwaggerUI(c =>
-{
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Fertile Notify API v1");
-});
-
 // --- MIDDLEWARE PIPELINE ---
 
-// Seeder
-await DbSeeder.SeedAsync(app);
+// Initial Tools
+app.UseForwardedHeaders();
+await DbSeeder.SeedAsync(app); // Seeder
 
+// Security & Optimization
 app.UseCors("AllowFrontend");
 app.UseRateLimiter();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 
+// Documentation
+app.UseSwaggerConfig();
+
+// Authentication & Authorization
 app.UseAuthentication();
 app.UseAuthorization();
 
+// Monitoring & Diagnostics
 app.UseSerilogRequestLogging();
-
-app.MapControllers();
 app.MapHealthChecks("/health");
+
+// Endpoints
+app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
Introduce modular extension methods and clean up Program.cs. Added new extension classes: ApplicationServiceExtension, AuthExtension, EnvExtension, InfrastructureExtension, SwaggerExtension, and WebExtension. These move repository/service registrations, auth setup, environment variable mapping, DB/Redis/RabbitMQ configuration, Swagger setup, CORS/rate-limiting/controllers/validation, and notification senders out of Program.cs. Program.cs now calls builder.Configuration.AddCustomEnvVariables() and composes services via AddWebConfig(), AddSwaggerConfig(), AddInfrastructureConfig(...), AddAuthConfig(...), and AddApplicationServices(), and uses UseSwaggerConfig() for middleware. This refactor improves separation of concerns and readability while preserving existing behavior (DbSeeder seeding, Serilog, health checks, authentication, and middleware pipeline).