### PR TITLE
Add password reset flow and rename login DTO

### DIFF
--- a/backend/FertileNotify.API/Controllers/AuthController.cs
+++ b/backend/FertileNotify.API/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using FertileNotify.Application.Interfaces;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
+using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FertileNotify.API.Controllers
@@ -33,7 +34,7 @@ namespace FertileNotify.API.Controllers
         }
 
         [HttpPost("login")]
-        public async Task<IActionResult> Login([FromBody] LoginRequest request)
+        public async Task<IActionResult> Login([FromBody] UserLoginRequest request)
         {
             var subscriber = await GetSubscriber(request.Email);
 
@@ -88,6 +89,27 @@ namespace FertileNotify.API.Controllers
             await _subscriberRepository.SaveAsync(subscriber);
 
             return Ok(ApiResponse<object>.SuccessResult(new { AccessToken = newAccessToken, RefreshToken = newRefreshToken }, "Token refreshed successfully."));
+        }
+
+        [HttpPost("forgot-password")]
+        public async Task<IActionResult> ForgotPassword([FromBody] string email)
+        {
+            var subscriber = await GetSubscriber(email);
+            var otpCode = await _otpService.GenerateOtpAsync(subscriber.Id);
+            await _emailService.SendEmailAsync(subscriber.Email.ToString(), "Password Reset OTP", $"Your OTP for password reset is: {otpCode}.");
+            return Ok(ApiResponse<object>.SuccessResult(default!, "A special 6-character code valid for 5 minutes has been sent to your email address. Please enter this code to reset your password."));
+        }
+
+        [HttpPost("reset-password")]
+        public async Task<IActionResult> ResetPassword([FromBody] UserResetPasswordRequest request)
+        {
+            var subscriber = await GetSubscriber(request.Email);
+            var isValid = await _otpService.VerifyOtpAsync(subscriber.Id, request.OtpCode);
+            if (!isValid)
+                throw new UnauthorizedException("Invalid or expired OTP code");
+            subscriber.UpdatePassword(Password.Create(request.NewPassword));
+            await _subscriberRepository.SaveAsync(subscriber);
+            return Ok(ApiResponse<object>.SuccessResult(default!, "Password reset successful."));
         }
 
         [NonAction]

--- a/backend/FertileNotify.API/Models/Requests/UserLoginRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/UserLoginRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace FertileNotify.API.Models.Requests
 {
-    public class LoginRequest
+    public class UserLoginRequest
     {
         public string Email { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;

--- a/backend/FertileNotify.API/Models/Requests/UserResetPasswordRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/UserResetPasswordRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace FertileNotify.API.Models.Requests
+{
+    public class UserResetPasswordRequest
+    {
+        public string Email { get; set; } = string.Empty;
+        public string OtpCode { get; set; } = string.Empty;
+        public string NewPassword { get; set; } = string.Empty;
+    }
+}

--- a/backend/FertileNotify.API/Validators/UserLoginRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/UserLoginRequestValidator.cs
@@ -3,9 +3,9 @@ using FluentValidation;
 
 namespace FertileNotify.API.Validators
 {
-    public class LoginRequestValidator : AbstractValidator<LoginRequest>
+    public class UserLoginRequestValidator : AbstractValidator<UserLoginRequest>
     {
-        public LoginRequestValidator() 
+        public UserLoginRequestValidator() 
         {
             RuleFor(x => x.Email)
                 .NotEmpty().WithMessage("Email is a required field.")

--- a/backend/FertileNotify.API/Validators/UserResetPasswordRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/UserResetPasswordRequestValidator.cs
@@ -1,0 +1,33 @@
+﻿using FertileNotify.API.Models.Requests;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class UserResetPasswordRequestValidator : AbstractValidator<UserResetPasswordRequest>
+    {
+        public UserResetPasswordRequestValidator() 
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("Email is required.")
+                .EmailAddress().WithMessage("Invalid email format.");
+            RuleFor(x => x.OtpCode)
+                .NotEmpty().WithMessage("Reset OTP Code is required.");
+            RuleFor(x => x.NewPassword)
+                .NotEmpty().WithMessage("Password is a required field.")
+                .Must(IsValidPassword)
+                .WithMessage("Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one digit.");
+        }
+
+        private bool IsValidPassword(string password)
+        {
+            if (string.IsNullOrEmpty(password) ||
+                password.Length < 8 ||
+                !password.Any(char.IsUpper) ||
+                !password.Any(char.IsLower) ||
+                !password.Any(char.IsDigit)
+            )
+                return false;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Introduce forgot-password and reset-password endpoints in AuthController to support OTP-based password reset: generates/sends a 6-character OTP via email and verifies OTP to update the subscriber password. Add a new UserResetPasswordRequest DTO and corresponding FluentValidation (UserResetPasswordRequestValidator) enforcing email format and strong password rules. Rename LoginRequest to UserLoginRequest (and its validator) and update the Login action to accept the renamed DTO. Minor using/import added for controller.