### PR TITLE
Rename SubjectTemplate/BodyTemplate to Subject/Body

### DIFF
--- a/backend/FertileNotify.API/Controllers/TemplatesController.cs
+++ b/backend/FertileNotify.API/Controllers/TemplatesController.cs
@@ -5,9 +5,9 @@ using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
 namespace FertileNotify.API.Controllers
@@ -35,13 +35,13 @@ namespace FertileNotify.API.Controllers
 
             var result = templates.Select(t => new
             {
-                Id = t.Id,
-                Name = t.Name,
-                Description = t.Description,
-                Event = t.EventType.Name,
-                Channel = t.Channel.Name,
-                Subject = t.SubjectTemplate,
-                Body = t.BodyTemplate,
+                t.Id,
+                t.Name,
+                t.Description,
+                t.EventType,
+                t.Channel,
+                t.Subject,
+                t.Body,
                 Source = t.SubscriberId == null ? "Default" : "Custom"
             });
 
@@ -56,13 +56,13 @@ namespace FertileNotify.API.Controllers
 
             var result = logs.Select(t => new
             {
-                Id = t.Id,
-                Recipient = t.Recipient,
-                Channel = t.Channel.Name,
-                Event = t.EventType.Name,
-                Subject = t.Subject,
-                Body = t.Body,
-                CreatedAt = t.CreatedAt
+                t.Id,
+                t.Recipient,
+                t.Channel,
+                t.EventType,
+                t.Subject,
+                t.Body,
+                t.CreatedAt
             });
 
             return Ok(ApiResponse<object>.SuccessResult(result, "Notification logs retrieved successfully."));
@@ -88,13 +88,13 @@ namespace FertileNotify.API.Controllers
 
             var result = templates.Select(t => new
             {
-                Id = t.Id,
-                Name = t.Name,
-                Description = t.Description,
-                Event = t.EventType.Name,
-                Channel = t.Channel.Name,
-                Subject = t.SubjectTemplate,
-                Body = t.BodyTemplate,
+                t.Id,
+                t.Name,
+                t.Description,
+                t.EventType,
+                t.Channel,
+                t.Subject,
+                t.Body,
                 Source = t.SubscriberId == null ? "Default" : "Custom"
             });
 
@@ -112,7 +112,7 @@ namespace FertileNotify.API.Controllers
 
             if (existingTemplate != null)
             {
-                existingTemplate.Update(request.Name, request.Description, request.SubjectTemplate, request.BodyTemplate);
+                existingTemplate.Update(request.Name, request.Description, request.Subject, request.Body);
                 await _templateRepository.SaveAsync();
             }
             else
@@ -123,8 +123,8 @@ namespace FertileNotify.API.Controllers
                     request.Description, 
                     eventType, 
                     channel, 
-                    request.SubjectTemplate, 
-                    request.BodyTemplate
+                    request.Subject, 
+                    request.Body
                 );
                 await _templateRepository.AddAsync(newTemplate);
             }

--- a/backend/FertileNotify.API/Models/Requests/CreateTemplateRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/CreateTemplateRequest.cs
@@ -6,7 +6,7 @@
         public string Description { get; set; } = null!;
         public string EventType { get; set; } = null!;
         public string Channel { get; set; } = null!;
-        public string SubjectTemplate { get; set; } = null!;
-        public string BodyTemplate { get; set; } = null!;
+        public string Subject { get; set; } = null!;
+        public string Body { get; set; } = null!;
     }
 }

--- a/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/CreateTemplateRequestValidator.cs
@@ -24,11 +24,12 @@ namespace FertileNotify.API.Validators
                 .NotEmpty().WithMessage("Channel is a required field.")
                 .Must(ChannelValid).WithMessage("Invalid Channel type.");
 
-            RuleFor(x => x.SubjectTemplate)
-                .NotEmpty().WithMessage("SubjectTemplate is required.");
+            RuleFor(x => x.Subject)
+                .NotEmpty().WithMessage("Subject is required.");
 
-            RuleFor(x => x.BodyTemplate)
-                .NotEmpty().WithMessage("BodyTemplate is required.");
+            RuleFor(x => x.Body)
+                .NotEmpty().WithMessage("Body is required.")
+                .Must(body => body.Contains("{{UnsubscriberLink}}")).WithMessage("UnsubscriberLink is required.");
         }
 
         private bool BeAValidEventType(string eventType)

--- a/backend/FertileNotify.Application/UseCases/SendNotification/SendNotificationHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/SendNotification/SendNotificationHandler.cs
@@ -5,6 +5,7 @@ using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.Exceptions;
 using FertileNotify.Domain.ValueObjects;
+
 using MassTransit;
 using Microsoft.Extensions.Logging;
 
@@ -107,9 +108,9 @@ namespace FertileNotify.Application.UseCases.SendNotification
             var (subscriber, subscription) = await GetAndValidateEntities(message.SubscriberId, eventType, channel);
 
             var unsubscribeToken = _securityService.GenerateUnsubscribeToken(message.Recipient, message.SubscriberId);
-            if (!message.Parameters.ContainsKey("UnsubscribeLink"))
+            if (!message.Parameters.ContainsKey("UnsubscriberLink"))
             {
-                message.Parameters["UnsubscribeLink"] = 
+                message.Parameters["UnsubscriberLink"] = 
                     $"http://fertile-notify.enesefetokta.shop/unsubscribe?recipient={message.Recipient}&subId={message.SubscriberId}&token={unsubscribeToken}";
             }
 
@@ -153,8 +154,8 @@ namespace FertileNotify.Application.UseCases.SendNotification
             var template = await _templateRepository.GetTemplateAsync(eventType, channel, subscriberId)
                 ?? throw new NotFoundException($"No template for {eventType.Name} on {channel.Name}");
 
-            var subject = _templateEngine.Render(template.SubjectTemplate, channel, parameters);
-            var body = _templateEngine.Render(template.BodyTemplate, channel, parameters);
+            var subject = _templateEngine.Render(template.Subject, channel, parameters);
+            var body = _templateEngine.Render(template.Body, channel, parameters);
 
             return (subject, body);
         }

--- a/backend/FertileNotify.Domain/Entities/Notification.cs
+++ b/backend/FertileNotify.Domain/Entities/Notification.cs
@@ -3,15 +3,15 @@ namespace FertileNotify.Domain.Entities
     public class Notification
     {
         public Guid Id { get; private set; }
-        public string Title { get; private set; }
-        public string Message { get; private set; }
+        public string Subject { get; private set; }
+        public string Body { get; private set; }
         public DateTime CreateAt { get; private set; }
 
-        public Notification(string title, string message)
+        public Notification(string subject, string body)
         {
             Id = Guid.NewGuid();
-            Title = title;
-            Message = message;
+            Subject = subject;
+            Body = body;
             CreateAt = DateTime.UtcNow;
         }
     }

--- a/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
@@ -11,8 +11,8 @@ namespace FertileNotify.Domain.Entities
         public string? Description { get; private set; } = string.Empty;
         public EventType EventType { get; private set; } = default!;
         public NotificationChannel Channel { get; private set; } = default!;
-        public string SubjectTemplate { get; private set; } = string.Empty;
-        public string BodyTemplate { get; private set; } = string.Empty;
+        public string Subject { get; private set; } = string.Empty;
+        public string Body { get; private set; } = string.Empty;
 
         private NotificationTemplate() { }
 
@@ -24,50 +24,23 @@ namespace FertileNotify.Domain.Entities
             Description = description;
             EventType = eventType;
             Channel = channel;
-            SubjectTemplate = subject;
-            BodyTemplate = body;
+            Subject = subject;
+            Body = body;
         }
 
         public static NotificationTemplate CreateGlobal(string name, string description, EventType eventType, NotificationChannel channel, string subject, string body)
-        {
-            if (string.IsNullOrWhiteSpace(subject))
-                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
-            if (string.IsNullOrWhiteSpace(body))
-                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
-
-            return new NotificationTemplate(name, description, eventType, channel, subject, body, null);
-        }
+            => new NotificationTemplate(name, description, eventType, channel, subject, body, null);
 
         public static NotificationTemplate CreateCustom(Guid subscriberId, string name, string description, EventType eventType, NotificationChannel channel, string subject, string body)
-        {
-            if (string.IsNullOrWhiteSpace(subject))
-                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
-
-            if (string.IsNullOrWhiteSpace(body))
-                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
-
-            return new NotificationTemplate(name, description, eventType, channel, subject, body, subscriberId);
-        }
+            => new NotificationTemplate(name, description, eventType, channel, subject, body, subscriberId);
 
         public void Update(string name, string description, string subject, string body)
         {
-            if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentException("name", nameof(name));
-
-            if (string.IsNullOrWhiteSpace(description))
-                throw new ArgumentException("description", nameof(description));
-
-            if (string.IsNullOrWhiteSpace(subject))
-                throw new ArgumentException("Subject template cannot be null or empty.", nameof(subject));
-
-            if (string.IsNullOrWhiteSpace(body))
-                throw new ArgumentException("Body template cannot be null or empty.", nameof(body));
-
             Name = name;
             Description = description;
 
-            SubjectTemplate = subject;
-            BodyTemplate = body;
+            Subject = subject;
+            Body = body;
         }
     }
 }

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationTemplateConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationTemplateConfiguration.cs
@@ -36,11 +36,11 @@ namespace FertileNotify.Infrastructure.Persistence.Configurations
                 .HasMaxLength(50)
                 .IsRequired();
 
-            builder.Property(t => t.SubjectTemplate)
+            builder.Property(t => t.Subject)
                 .HasMaxLength(200)
                 .IsRequired();
 
-            builder.Property(t => t.BodyTemplate)
+            builder.Property(t => t.Body)
                 .IsRequired();
         }
     }


### PR DESCRIPTION
Rename template fields across the codebase and adjust related logic: update API request/validator, controllers, domain entities, persistence configuration, and template rendering to use Subject and Body instead of SubjectTemplate/BodyTemplate. Also: update Notification entity (Title/Message -> Subject/Body), change SendNotificationHandler to expect and set the "UnsubscriberLink" parameter key (and render template.Subject/Body), enforce that template body contains "{{UnsubscriberLink}}" in the validator, simplify controller projections and remove an unused using, and adjust NotificationTemplate factory/update implementations and EF mappings accordingly.