### PR TITLE
Add notification complaint feature

### DIFF
--- a/backend/FertileNotify.API/Controllers/ComplaintController.cs
+++ b/backend/FertileNotify.API/Controllers/ComplaintController.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using FertileNotify.API.Models.Requests;
+using FertileNotify.Application.UseCases.NotificationComplaint;
+using FertileNotify.API.Models.Responses;
+using FertileNotify.Application.Interfaces;
+
+namespace FertileNotify.API.Controllers
+{
+    [ApiController]
+    [Route("api/complaints")]
+    [Authorize]
+    public class ComplaintController : ControllerBase
+    {
+        private readonly NotificationComplaintHandler _complaintHandler;
+        private readonly INotificationComplaintRepository _complaintRepository;
+
+        public ComplaintController(NotificationComplaintHandler complaintHandler, INotificationComplaintRepository complaintRepository)
+        {
+            _complaintHandler = complaintHandler;
+            _complaintRepository = complaintRepository;
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> ComplaintSubmit([FromBody] ComplaintRequest request)
+        {
+            await _complaintHandler.HandleAsync(new NotificationComplaintCommand
+            {
+                SubscriberId = request.SubscriberId,
+                ReporterEmail = request.ReporterEmail,
+                Reason = request.Reason,
+                Description = request.Description,
+                NotificationSubject = request.NotificationSubject,
+                NotificationBody = request.NotificationBody
+            });
+
+            return Ok(ApiResponse<object>.SuccessResult(null!, "Complaint submitted successfully."));
+        }
+
+        [HttpGet("{subscriberId}")]
+        public IActionResult GetComplaints(Guid subscriberId)
+        {
+            var complaints = _complaintRepository.GetComplaintsBySubscriberIdAsync(subscriberId);
+            var result = complaints.Result.Select(c => new
+            {
+                c.Id,
+                c.ReporterEmail,
+                Reason = c.Reason.ToString(),
+                c.Description,
+                c.NotificationSubject,
+                c.NotificationBody,
+                c.CreatedAt
+            });
+            return Ok(ApiResponse<object>.SuccessResult(result, "Complaints retrieved successfully."));
+        }
+    }
+}

--- a/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
+++ b/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
@@ -13,6 +13,8 @@ using FertileNotify.Application.UseCases.RevokeApiKey;
 using FertileNotify.Application.UseCases.SetChannelSetting;
 using FertileNotify.Infrastructure.Notifications;
 using FertileNotify.Infrastructure.Persistence;
+using FertileNotify.Application.UseCases.NotificationComplaint;
+
 using Mjml.Net;
 
 namespace FertileNotify.API.Extensions;
@@ -30,6 +32,7 @@ public static class ApplicationServiceExtension
         services.AddScoped<ISubscriberChannelRepository, EfSubscriberChannelRepository>();
         services.AddScoped<IStatsRepository, EfStatsRepository>();
         services.AddScoped<IBlacklistRepository, EfBlacklistRepository>();
+        services.AddScoped<INotificationComplaintRepository, EfINotificationComplaintRepository>();
 
         // Application Services
         services.AddScoped<IStatisticsService, StatisticsService>();
@@ -50,6 +53,7 @@ public static class ApplicationServiceExtension
         services.AddScoped<CreateApiKeyHandler>();
         services.AddScoped<RevokeApiKeyHandler>();
         services.AddScoped<SetChannelSettingHandler>();
+        services.AddScoped<NotificationComplaintHandler>();
 
         // Notification Senders
         services.AddNotificationSenders();

--- a/backend/FertileNotify.API/Models/Requests/ComplaintRequest.cs
+++ b/backend/FertileNotify.API/Models/Requests/ComplaintRequest.cs
@@ -1,0 +1,12 @@
+﻿namespace FertileNotify.API.Models.Requests
+{
+    public class ComplaintRequest
+    {
+        public Guid SubscriberId { get; set; }
+        public string ReporterEmail { get; set; } = null!;
+        public string Reason { get; set; } = null!;
+        public string Description { get; set; } = null!;
+        public string NotificationSubject { get; set; } = null!;
+        public string NotificationBody { get; set; } = null!;
+    }
+}

--- a/backend/FertileNotify.API/Validators/ComplaintRequestValidator.cs
+++ b/backend/FertileNotify.API/Validators/ComplaintRequestValidator.cs
@@ -1,0 +1,35 @@
+﻿using FertileNotify.API.Models.Requests;
+using FertileNotify.Domain.Enums;
+using FluentValidation;
+
+namespace FertileNotify.API.Validators
+{
+    public class ComplaintRequestValidator : AbstractValidator<ComplaintRequest>
+    {
+        public ComplaintRequestValidator() 
+        {
+            RuleFor(x => x.SubscriberId)
+                .NotEmpty().WithMessage("SubscriberId is required.");
+
+            RuleFor(x => x.ReporterEmail)
+                .NotEmpty().WithMessage("ReporterEmail is required.")
+                .EmailAddress().WithMessage("ReporterEmail must be a valid email address.");
+
+            RuleFor(x => x.Reason)
+                .NotEmpty().WithMessage("Reason is required.")
+                .Must(ReasonValid).WithMessage("Invalid Reason Type.");
+
+            RuleFor(x => x.Description)
+                .MaximumLength(1000).WithMessage("Description cannot exceed 1000 characters.");
+
+            RuleFor(x => x.NotificationSubject)
+                .NotEmpty().WithMessage("NotificationSubject is required.");
+
+            RuleFor(x => x.NotificationBody)
+                .NotEmpty().WithMessage("NotificationBody is required.");
+        }
+
+        private bool ReasonValid(string reason)
+            => Enum.TryParse<ComplaintType>(reason, ignoreCase: true, out _);
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/INotificationComplaintRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationComplaintRepository.cs
@@ -1,0 +1,11 @@
+﻿using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface INotificationComplaintRepository
+    {
+        Task SaveAsync(NotificationComplaint complaint);
+        Task<NotificationComplaint?> GetByIdAsync(Guid id);
+        Task<List<NotificationComplaint>> GetComplaintsBySubscriberIdAsync(Guid subscriberId);
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/NotificationComplaint/NotificationComplaintCommand.cs
+++ b/backend/FertileNotify.Application/UseCases/NotificationComplaint/NotificationComplaintCommand.cs
@@ -1,0 +1,12 @@
+﻿namespace FertileNotify.Application.UseCases.NotificationComplaint
+{
+    public class NotificationComplaintCommand
+    {
+        public Guid SubscriberId { get; set; }
+        public string ReporterEmail { get; set; } = null!;
+        public string Reason { get; set; } = null!;
+        public string? Description { get; set; }
+        public string NotificationSubject { get; set; } = null!;
+        public string NotificationBody { get; set; } = null!;
+    }
+}

--- a/backend/FertileNotify.Application/UseCases/NotificationComplaint/NotificationComplaintHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/NotificationComplaint/NotificationComplaintHandler.cs
@@ -1,0 +1,57 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace FertileNotify.Application.UseCases.NotificationComplaint
+{
+    public class NotificationComplaintHandler
+    {
+        private readonly IEmailService _emailService;
+        private readonly INotificationComplaintRepository _notificationComplaintRepository;
+        private readonly ILogger<NotificationComplaintHandler> _logger;
+        private readonly ISubscriberRepository _subscriberRepository;
+
+        public NotificationComplaintHandler(
+            IEmailService emailService, 
+            INotificationComplaintRepository notificationComplaintRepository, 
+            ILogger<NotificationComplaintHandler> logger,
+            ISubscriberRepository subscriberRepository
+        )
+        {
+            _emailService = emailService;
+            _notificationComplaintRepository = notificationComplaintRepository;
+            _logger = logger;
+            _subscriberRepository = subscriberRepository;
+        }
+
+        public async Task HandleAsync(NotificationComplaintCommand command)
+        {
+            try
+            {
+                var complaint = Domain.Entities.NotificationComplaint.Create(
+                    command.SubscriberId,
+                    EmailAddress.Create(command.ReporterEmail),
+                    Enum.Parse<Domain.Enums.ComplaintType>(command.Reason, ignoreCase: true),
+                    command.Description,
+                    command.NotificationSubject,
+                    command.NotificationBody
+                );
+                await _notificationComplaintRepository.SaveAsync(complaint);
+                _logger.LogInformation("Notification complaint recorded: {ComplaintId}", complaint.Id);
+
+                var subscriber = await _subscriberRepository.GetByIdAsync(command.SubscriberId);
+
+                await _emailService.SendEmailAsync(
+                    subscriber!.Email.Value,
+                    "New Notification Complaint", 
+                    $"A new complaint has been filed by {command.ReporterEmail} for SubscriberId: {command.SubscriberId}. Reason: {command.Reason}. Description: {command.Description}"
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while handling notification complaint for SubscriberId: {SubscriberId}", command.SubscriberId);
+                throw;
+            }
+        }
+    }
+}

--- a/backend/FertileNotify.Domain/Entities/NotificationComplaint.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationComplaint.cs
@@ -1,0 +1,61 @@
+﻿using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.ValueObjects;
+
+namespace FertileNotify.Domain.Entities
+{
+    public class NotificationComplaint
+    {
+        public Guid Id { get; private set; }
+        public Guid SubscriberId { get; private set; }
+
+        public EmailAddress ReporterEmail { get; private set; } = default!;
+
+        public ComplaintType Reason { get; private set; }
+        public string? Description { get; private set; }
+
+        public string NotificationSubject { get; private set; } = string.Empty;
+        public string NotificationBody { get; private set; } = string.Empty;
+
+        public DateTime CreatedAt { get; private set; }
+
+        private NotificationComplaint() { }
+
+        public NotificationComplaint(
+            Guid subscriberId,
+            EmailAddress reporterEmail,
+            ComplaintType reason,
+            string? description,
+            string notificationSubject,
+            string notificationBody
+        )
+        {
+            Id = Guid.NewGuid();
+            SubscriberId = subscriberId;
+            ReporterEmail = reporterEmail;
+            Reason = reason;
+            Description = description;
+            NotificationSubject = notificationSubject;
+            NotificationBody = notificationBody;
+            CreatedAt = DateTime.UtcNow;
+        }
+
+        public static NotificationComplaint Create(
+            Guid subscriberId,
+            EmailAddress reporterEmail,
+            ComplaintType type,
+            string? description,
+            string notificationSubject,
+            string notificationBody
+        )
+        {
+            return new NotificationComplaint(
+                subscriberId,
+                reporterEmail,
+                type,
+                description,
+                notificationSubject,
+                notificationBody
+            );
+        }
+    }
+}

--- a/backend/FertileNotify.Domain/Enums/ComplaintType.cs
+++ b/backend/FertileNotify.Domain/Enums/ComplaintType.cs
@@ -1,0 +1,12 @@
+﻿namespace FertileNotify.Domain.Enums
+{
+    public enum ComplaintType 
+    { 
+        Spam,
+        InappropriateContent,
+        Harassment,
+        PrivacyViolation,
+        IntellectualPropertyInfringement,
+        Other
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Migrations/20260317075851_InitialCreation.Designer.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260317075851_InitialCreation.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FertileNotify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260315093715_InitialCreation")]
+    [Migration("20260317075851_InitialCreation")]
     partial class InitialCreation
     {
         /// <inheritdoc />
@@ -90,6 +90,46 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.ToTable("ForbiddenRecipients");
                 });
 
+            modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationComplaint", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<string>("NotificationBody")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("NotificationSubject")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Reason")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ReporterEmail")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("NotificationComplaints");
+                });
+
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationLog", b =>
                 {
                     b.Property<Guid>("Id")
@@ -143,7 +183,7 @@ namespace FertileNotify.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<string>("BodyTemplate")
+                    b.Property<string>("Body")
                         .IsRequired()
                         .HasColumnType("text");
 
@@ -167,7 +207,7 @@ namespace FertileNotify.Infrastructure.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
-                    b.Property<string>("SubjectTemplate")
+                    b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");

--- a/backend/FertileNotify.Infrastructure/Migrations/20260317075851_InitialCreation.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/20260317075851_InitialCreation.cs
@@ -62,6 +62,24 @@ namespace FertileNotify.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "NotificationComplaints",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubscriberId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReporterEmail = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    Reason = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    NotificationSubject = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    NotificationBody = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationComplaints", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "NotificationLogs",
                 columns: table => new
                 {
@@ -91,8 +109,8 @@ namespace FertileNotify.Infrastructure.Migrations
                     Description = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
                     EventType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     Channel = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
-                    SubjectTemplate = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
-                    BodyTemplate = table.Column<string>(type: "text", nullable: false)
+                    Subject = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -171,6 +189,9 @@ namespace FertileNotify.Infrastructure.Migrations
 
             migrationBuilder.DropTable(
                 name: "ForbiddenRecipients");
+
+            migrationBuilder.DropTable(
+                name: "NotificationComplaints");
 
             migrationBuilder.DropTable(
                 name: "NotificationLogs");

--- a/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/FertileNotify.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -87,6 +87,46 @@ namespace FertileNotify.Infrastructure.Migrations
                     b.ToTable("ForbiddenRecipients");
                 });
 
+            modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationComplaint", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<string>("NotificationBody")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("NotificationSubject")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Reason")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ReporterEmail")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.Property<Guid>("SubscriberId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("NotificationComplaints");
+                });
+
             modelBuilder.Entity("FertileNotify.Domain.Entities.NotificationLog", b =>
                 {
                     b.Property<Guid>("Id")
@@ -140,7 +180,7 @@ namespace FertileNotify.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<string>("BodyTemplate")
+                    b.Property<string>("Body")
                         .IsRequired()
                         .HasColumnType("text");
 
@@ -164,7 +204,7 @@ namespace FertileNotify.Infrastructure.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
-                    b.Property<string>("SubjectTemplate")
+                    b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");

--- a/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -16,6 +16,7 @@ namespace FertileNotify.Infrastructure.Persistence
         public DbSet<SubscriberChannelSetting> SubscriberChannelSettings { get; set; }
         public DbSet<SubscriberDailyStats> DailyStats { get; set; }
         public DbSet<ForbiddenRecipient> ForbiddenRecipients { get; set; }
+        public DbSet<NotificationComplaint> NotificationComplaints { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationComplaintConfiguration.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/Configurations/NotificationComplaintConfiguration.cs
@@ -1,0 +1,37 @@
+﻿using FertileNotify.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FertileNotify.Infrastructure.Persistence.Configurations
+{
+    public class NotificationComplaintConfiguration : IEntityTypeConfiguration<NotificationComplaint>
+    {
+        public void Configure(EntityTypeBuilder<NotificationComplaint> builder) 
+        {
+            builder.HasKey(nc => nc.Id);
+
+            builder.Property(nc => nc.ReporterEmail)
+                .HasConversion(
+                    email => email.Value,
+                    value => new Domain.ValueObjects.EmailAddress(value)
+                )
+                .HasMaxLength(150)
+                .IsRequired();
+
+            builder.Property(nc => nc.Reason)
+                .HasConversion<string>()
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(nc => nc.Description)
+                .HasMaxLength(500);
+
+            builder.Property(nc => nc.NotificationSubject)
+                .HasMaxLength(200)
+                .IsRequired();
+
+            builder.Property(nc => nc.NotificationBody)
+                .IsRequired();
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Persistence/EfINotificationComplaintRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfINotificationComplaintRepository.cs
@@ -1,0 +1,32 @@
+﻿using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FertileNotify.Infrastructure.Persistence
+{
+    public class EfINotificationComplaintRepository : INotificationComplaintRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public EfINotificationComplaintRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<NotificationComplaint?> GetByIdAsync(Guid id)
+            => await _context.NotificationComplaints.AsNoTracking().FirstOrDefaultAsync(nc => nc.Id == id);
+
+        public async Task<List<NotificationComplaint>> GetComplaintsBySubscriberIdAsync(Guid subscriberId)
+            => await _context.NotificationComplaints.AsNoTracking().Where(nc => nc.SubscriberId == subscriberId).OrderByDescending(nc => nc.CreatedAt).ToListAsync();
+
+        public async Task SaveAsync(NotificationComplaint complaint)
+        {
+            var exists = await _context.NotificationComplaints.AnyAsync(nc => nc.Id == complaint.Id);
+            if (!exists)
+                _context.NotificationComplaints.Add(complaint);
+            else
+                _context.NotificationComplaints.Update(complaint);
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
Introduce support for notification complaints: adds API endpoints (ComplaintController) with request model and FluentValidation, domain entity (NotificationComplaint) and ComplaintType enum, application command and handler (records complaint, logs and emails subscriber), repository interface and EF implementation, and EF configuration. Registers repository and handler in DI and exposes NotificationComplaints DbSet in ApplicationDbContext. Includes migration/snapshot updates to create the NotificationComplaints table and updates to the InitialCreation migration and NotificationLog subject/body naming.