### PR TITLE
Add notification log service and retention worker

### DIFF
--- a/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
+++ b/backend/FertileNotify.API/Extensions/ApplicationServiceExtension.cs
@@ -36,6 +36,7 @@ public static class ApplicationServiceExtension
 
         // Application Services
         services.AddScoped<IStatisticsService, StatisticsService>();
+        services.AddScoped<INotificationLogService, NotificationLogService>();
         services.AddScoped<IEmailService, SmtpEmailService>();
         services.AddScoped<ISecurityService, SecurityService>();
         services.AddScoped<TemplateEngine>();

--- a/backend/FertileNotify.API/Extensions/InfrastructureExtension.cs
+++ b/backend/FertileNotify.API/Extensions/InfrastructureExtension.cs
@@ -51,6 +51,9 @@ public static class InfrastructureExtension
             });
         });
 
+        // Background Workers
+        services.AddHostedService<LogRetentionWorker>();
+
         return services;
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationLogRepository.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Entities;
 
 namespace FertileNotify.Application.Interfaces
 {
@@ -7,5 +7,10 @@ namespace FertileNotify.Application.Interfaces
         Task AddAsync(NotificationLog log);
         Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count);
         Task<List<NotificationLog>> GetLogsForStatsAsync(Guid subscriberId, DateTime startDate);
+        
+        // GDPR Methods
+        Task<List<NotificationLog>> GetLogsForAnonymizationAsync(DateTime cutOffDate);
+        Task UpdateRangeAsync(IEnumerable<NotificationLog> logs);
+        Task DeleteLogsOlderThanAsync(DateTime cutOffDate);
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/INotificationLogService.cs
+++ b/backend/FertileNotify.Application/Interfaces/INotificationLogService.cs
@@ -1,0 +1,26 @@
+using FertileNotify.Application.Contracts;
+using FertileNotify.Domain.Entities;
+
+namespace FertileNotify.Application.Interfaces
+{
+    public interface INotificationLogService
+    {
+        Task LogSuccessAsync(
+            ProcessNotificationMessage message, 
+            string subject, 
+            string body, 
+            Subscription subscription);
+
+        Task LogFailureAsync(
+            ProcessNotificationMessage message, 
+            string? subject, 
+            string? body, 
+            string errorReason);
+
+        Task LogRejectedAsync(
+            ProcessNotificationMessage message,
+            string? subject,
+            string? body,
+            string errorReason);
+    }
+}

--- a/backend/FertileNotify.Application/Interfaces/IStatisticsService.cs
+++ b/backend/FertileNotify.Application/Interfaces/IStatisticsService.cs
@@ -5,6 +5,9 @@ namespace FertileNotify.Application.Interfaces
 {
     public interface IStatisticsService
     {
-        Task<StatisticsDto> GetSubscriberStatsAsync(Guid subscriberId, string period, SubscriptionPlan plan);
+        Task<StatisticsDto> GetSubscriberStatsAsync(
+            Guid subscriberId, 
+            string period, 
+            SubscriptionPlan plan);
     }
 }

--- a/backend/FertileNotify.Application/Interfaces/IStatsRepository.cs
+++ b/backend/FertileNotify.Application/Interfaces/IStatsRepository.cs
@@ -6,7 +6,15 @@ namespace FertileNotify.Application.Interfaces
 {
     public interface IStatsRepository
     {
-        Task IncrementAsync(Guid subscriberId, NotificationChannel channel, EventType eventType, bool isSuccess);
-        Task<List<SubscriberDailyStats>> GetStatsAsync(Guid subscriberId, DateTime startDate, DateTime endDate);
+        Task IncrementAsync(
+            Guid subscriberId, 
+            NotificationChannel channel, 
+            EventType eventType, 
+            bool isSuccess);
+
+        Task<List<SubscriberDailyStats>> GetStatsAsync(
+            Guid subscriberId, 
+            DateTime startDate, 
+            DateTime endDate);
     }
 }

--- a/backend/FertileNotify.Application/Services/NotificationLogService.cs
+++ b/backend/FertileNotify.Application/Services/NotificationLogService.cs
@@ -1,0 +1,93 @@
+using FertileNotify.Application.Contracts;
+using FertileNotify.Application.Interfaces;
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace FertileNotify.Application.Services
+{
+    public class NotificationLogService : INotificationLogService
+    {
+        private readonly INotificationLogRepository _logRepository;
+        private readonly IStatsRepository _statsRepository;
+        private readonly ISubscriptionRepository _subscriptionRepository;
+        private readonly ILogger<NotificationLogService> _logger;
+
+        public NotificationLogService(
+            INotificationLogRepository logRepository,
+            IStatsRepository statsRepository,
+            ISubscriptionRepository subscriptionRepository,
+            ILogger<NotificationLogService> _logger)
+        {
+            _logRepository = logRepository;
+            _statsRepository = statsRepository;
+            _subscriptionRepository = subscriptionRepository;
+            this._logger = _logger;
+        }
+
+        public async Task LogSuccessAsync(ProcessNotificationMessage message, string subject, string body, Subscription subscription)
+        {
+            var channel = NotificationChannel.From(message.Channel);
+            var eventType = EventType.From(message.EventType);
+
+            var log = new NotificationLog(
+                message.SubscriberId,
+                message.Recipient,
+                channel,
+                eventType,
+                subject,
+                body);
+
+            log.SetResult(true);
+            await _logRepository.AddAsync(log);
+
+            await _statsRepository.IncrementAsync(message.SubscriberId, channel, eventType, true);
+            
+            subscription.IncreaseUsage();
+            await _subscriptionRepository.SaveAsync(message.SubscriberId, subscription);
+
+            _logger.LogInformation("[SUCCESS] Notification logged and usage updated for {Recipient}", message.Recipient);
+        }
+
+        public async Task LogFailureAsync(ProcessNotificationMessage message, string? subject, string? body, string errorReason)
+        {
+            var channel = NotificationChannel.From(message.Channel);
+            var eventType = EventType.From(message.EventType);
+
+            var log = new NotificationLog(
+                message.SubscriberId,
+                message.Recipient,
+                channel,
+                eventType,
+                subject ?? "[N/A]",
+                body ?? "[N/A]");
+
+            log.SetResult(false, errorReason);
+            await _logRepository.AddAsync(log);
+
+            await _statsRepository.IncrementAsync(message.SubscriberId, channel, eventType, false);
+
+            _logger.LogWarning("[FAILED] Notification failed for {Recipient}: {Reason}", message.Recipient, errorReason);
+        }
+
+        public async Task LogRejectedAsync(ProcessNotificationMessage message, string? subject, string? body, string errorReason)
+        {
+            var channel = NotificationChannel.From(message.Channel);
+            var eventType = EventType.From(message.EventType);
+
+            var log = new NotificationLog(
+                message.SubscriberId,
+                message.Recipient,
+                channel,
+                eventType,
+                subject ?? "[N/A]",
+                body ?? "[N/A]");
+
+            log.SetResult(false, errorReason, isRejected: true);
+            await _logRepository.AddAsync(log);
+            
+            _logger.LogWarning("[REJECTED] Notification rejected for {Recipient}: {Reason}", message.Recipient, errorReason);
+        }
+    }
+}

--- a/backend/FertileNotify.Application/Services/TemplateEngine.cs
+++ b/backend/FertileNotify.Application/Services/TemplateEngine.cs
@@ -22,7 +22,7 @@ namespace FertileNotify.Application.Services
             {
                 foreach (var param in parameters)
                 {
-                    rendered = rendered.Replace($"{{{param.Key}}}", param.Value ?? string.Empty);
+                    rendered = rendered.Replace($"{{{{{param.Key}}}}}", param.Value ?? string.Empty);
                 }
             }
 

--- a/backend/FertileNotify.Application/UseCases/SendNotification/SendNotificationHandler.cs
+++ b/backend/FertileNotify.Application/UseCases/SendNotification/SendNotificationHandler.cs
@@ -21,8 +21,8 @@ namespace FertileNotify.Application.UseCases.SendNotification
         private readonly ISubscriberChannelRepository _subscriberChannelRepository;
         private readonly IEnumerable<INotificationSender> _senders;
         private readonly TemplateEngine _templateEngine;
-        private readonly IStatsRepository _statsRepository;
         private readonly ISecurityService _securityService;
+        private readonly INotificationLogService _logService;
         private readonly ILogger<SendNotificationHandler> _logger;
         private readonly Dictionary<NotificationChannel, INotificationSender> _senderMap;
 
@@ -35,8 +35,8 @@ namespace FertileNotify.Application.UseCases.SendNotification
             ITemplateRepository templateRepository,
             ISubscriberChannelRepository subscriberChannelRepository,
             TemplateEngine templateEngine,
-            IStatsRepository statsRepository,
             ISecurityService securityService,
+            INotificationLogService logService,
             ILogger<SendNotificationHandler> logger)
         {
             _publishEndpoint = publishEndpoint;
@@ -48,8 +48,8 @@ namespace FertileNotify.Application.UseCases.SendNotification
             _templateRepository = templateRepository;
             _subscriberChannelRepository = subscriberChannelRepository;
             _templateEngine = templateEngine;
-            _statsRepository = statsRepository;
             _securityService = securityService;
+            _logService = logService;
             _logger = logger;
         }
 
@@ -102,32 +102,50 @@ namespace FertileNotify.Application.UseCases.SendNotification
             var channel = NotificationChannel.From(message.Channel);
             var eventType = EventType.From(message.EventType);
 
-            _logger.LogInformation("[HANDLING] Event: {Event}, Channel: {Channel}, Sub: {SubId}",
-                eventType.Name, channel.Name, message.SubscriberId);
+            string? subject = null;
+            string? body = null;
+            Subscription? subscription = null;
 
-            var (subscriber, subscription) = await GetAndValidateEntities(message.SubscriberId, eventType, channel);
-
-            var unsubscribeToken = _securityService.GenerateUnsubscribeToken(message.Recipient, message.SubscriberId);
-            if (!message.Parameters.ContainsKey("UnsubscriberLink"))
+            try
             {
-                message.Parameters["UnsubscriberLink"] = 
-                    $"http://fertile-notify.enesefetokta.shop/unsubscribe?recipient={message.Recipient}&subId={message.SubscriberId}&token={unsubscribeToken}";
+                var validated = await GetAndValidateEntities(message.SubscriberId, eventType, channel);
+                subscription = validated.Item2;
+
+                var unsubscribeToken = _securityService.GenerateUnsubscribeToken(message.Recipient, message.SubscriberId);
+                if (!message.Parameters.ContainsKey("UnsubscriberLink"))
+                    message.Parameters["UnsubscriberLink"] = 
+                        $"http://fertile-notify.enesefetokta.shop/unsubscribe?recipient={message.Recipient}&subId={message.SubscriberId}&token={unsubscribeToken}";
+
+                var content = await PrepareContent(message.SubscriberId, eventType, channel, message.Parameters);
+                subject = content.Subject;
+                body = content.Body;
+
+                var sender = GetSender(channel);
+                var channelSetting = await _subscriberChannelRepository.GetSettingAsync(message.SubscriberId, channel);
+
+                bool isSuccess = await sender.SendAsync(
+                    message.SubscriberId,
+                    message.Recipient,
+                    eventType,
+                    subject,
+                    body,
+                    channelSetting?.Settings);
+
+                if (isSuccess)
+                    await _logService.LogSuccessAsync(message, subject, body, subscription!);
+                else
+                    await _logService.LogFailureAsync(message, subject, body, "Provider rejected the message.");
             }
-
-            var (subject, body) = await PrepareContent(message.SubscriberId, eventType, channel, message.Parameters);
-
-            var sender = GetSender(channel);
-            var channelSetting = await _subscriberChannelRepository.GetSettingAsync(message.SubscriberId, channel);
-
-            bool isSuccess = await sender.SendAsync(
-                message.SubscriberId,
-                message.Recipient,
-                eventType,
-                subject,
-                body,
-                channelSetting?.Settings);
-
-            await FinalizeProcess(message.SubscriberId, eventType, channel, subscription, isSuccess, message.Recipient);
+            catch (BusinessRuleException ex)
+            {
+                await _logService.LogRejectedAsync(message, subject, body ,ex.Message);
+            }
+            catch (Exception ex)
+            {
+                await _logService.LogFailureAsync(message, subject, body, ex.Message);
+                _logger.LogError(ex, "Error processing notification for {Recipient}", message.Recipient);
+                throw;
+            }
         }
 
         private async Task<(Subscriber, Subscription)> GetAndValidateEntities(Guid subscriberId, EventType eventType, NotificationChannel channel)
@@ -168,29 +186,6 @@ namespace FertileNotify.Application.UseCases.SendNotification
                 throw new Exception($"System Error: No sender for {channel.Name}");
             }
             return sender;
-        }
-
-        private async Task FinalizeProcess(Guid subscriberId, EventType eventType, NotificationChannel channel, Subscription subscription, bool isSuccess, string recipient)
-        {
-            await _statsRepository.IncrementAsync(
-                subscriberId,
-                channel,
-                eventType,
-                isSuccess
-            );
-
-            if (isSuccess)
-            {
-                subscription.IncreaseUsage();
-                await _subscriptionRepository.SaveAsync(subscriberId, subscription);
-
-                _logger.LogInformation("[SUCCESS] Notification processed. Usage: {Used}/{Limit}",
-                    subscription.UsedThisMonth, subscription.MonthlyLimit);
-            }
-            else
-            {
-                _logger.LogWarning("[FAILED] Notification could not be sent to {Recipient}", recipient);
-            }
         }
     }
 }

--- a/backend/FertileNotify.Domain/Entities/NotificationLog.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationLog.cs
@@ -1,4 +1,4 @@
-﻿using FertileNotify.Domain.Enums;
+using FertileNotify.Domain.Enums;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 
@@ -31,10 +31,28 @@ namespace FertileNotify.Domain.Entities
             CreatedAt = DateTime.UtcNow;
         }
 
-        public void SetResult(bool isSuccess, string? error = null)
+        public void SetResult(bool isSuccess, string? error = null, bool isRejected = false)
         {
-            Status = isSuccess ? DeliveryStatus.Success : DeliveryStatus.Failed;
+            if (isRejected)
+                Status = DeliveryStatus.Rejected;
+            else
+                Status = isSuccess ? DeliveryStatus.Success : DeliveryStatus.Failed;
+
             ErrorMessage = error;
+        }
+
+        public void AnonymizeContent()
+        {
+            Subject = MaskVariables(Subject);
+            Body = MaskVariables(Body);
+        }
+
+        private string MaskVariables(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            
+            // Regex to find {{VariableName}} or {{ VariableName }}
+            return System.Text.RegularExpressions.Regex.Replace(input, @"\{\{.*?\}\}", "***");
         }
     }
 }

--- a/backend/FertileNotify.Domain/Enums/DeliveryStatus.cs
+++ b/backend/FertileNotify.Domain/Enums/DeliveryStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace FertileNotify.Domain.Enums
+namespace FertileNotify.Domain.Enums
 {
-    public enum DeliveryStatus { Pending, Success, Failed }
+    public enum DeliveryStatus { Pending, Success, Failed, Rejected }
 }

--- a/backend/FertileNotify.Infrastructure/BackgroundJobs/LogRetentionWorker.cs
+++ b/backend/FertileNotify.Infrastructure/BackgroundJobs/LogRetentionWorker.cs
@@ -1,0 +1,72 @@
+using FertileNotify.Application.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FertileNotify.Infrastructure.BackgroundJobs
+{
+    public class LogRetentionWorker : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<LogRetentionWorker> _logger;
+        private readonly TimeSpan _checkInterval = TimeSpan.FromHours(24);
+
+        public LogRetentionWorker(IServiceProvider serviceProvider, ILogger<LogRetentionWorker> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("LogRetentionWorker started.");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await ProcessLogsAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error occurred during log retention processing.");
+                }
+
+                await Task.Delay(_checkInterval, stoppingToken);
+            }
+        }
+
+        private async Task ProcessLogsAsync()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<INotificationLogRepository>();
+
+            var now = DateTime.UtcNow;
+            var anonymizationCutOff = now.AddDays(-7);
+            var deletionCutOff = now.AddDays(-30);
+
+            _logger.LogInformation("Starting log retention cleanup. Anonymization < {AnonymizationDate}, Deletion < {DeletionDate}", 
+                anonymizationCutOff, deletionCutOff);
+
+            await repository.DeleteLogsOlderThanAsync(deletionCutOff);
+            _logger.LogInformation("Completed deletion of logs older than 30 days.");
+
+            var logsToAnonymize = await repository.GetLogsForAnonymizationAsync(anonymizationCutOff);
+            
+            if (logsToAnonymize.Any())
+            {
+                foreach (var log in logsToAnonymize)
+                {
+                    log.AnonymizeContent();
+                }
+
+                await repository.UpdateRangeAsync(logsToAnonymize);
+                _logger.LogInformation("Anonymized {Count} logs between 7 and 30 days old.", logsToAnonymize.Count);
+            }
+            else
+            {
+                _logger.LogInformation("No logs found for anonymization.");
+            }
+        }
+    }
+}

--- a/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
+++ b/backend/FertileNotify.Infrastructure/Notifications/ConsoleNotificationSender.cs
@@ -8,12 +8,10 @@ namespace FertileNotify.Infrastructure.Notifications
 {
     public class ConsoleNotificationSender : INotificationSender
     {
-        private readonly INotificationLogRepository _logRepository;
         private readonly ILogger<ConsoleNotificationSender> _logger;
 
-        public ConsoleNotificationSender(INotificationLogRepository logRepository, ILogger<ConsoleNotificationSender> logger)
+        public ConsoleNotificationSender(ILogger<ConsoleNotificationSender> logger)
         {
-            _logRepository = logRepository;
             _logger = logger;
         }
 
@@ -24,18 +22,7 @@ namespace FertileNotify.Infrastructure.Notifications
             try
             {
                 _logger.LogInformation("[CONSOLE LOG] Subscriber: {SubId}, Recipient: {To}", subscriberId, recipient);
-
-                var log = new NotificationLog(
-                    subscriberId,
-                    recipient,
-                    NotificationChannel.Console,
-                    eventType,
-                    subject,
-                    body
-                );
-
-                await _logRepository.AddAsync(log);
-
+                await Task.CompletedTask;
                 return true;
             }
             catch { return false; }

--- a/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/DbSeeder.cs
@@ -39,9 +39,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Sent to new subscribers immediately after registration to welcome them to the platform.",
                         EventType.SubscriberRegistered,
                         channel,
-                        "Welcome to {AppName}!",
-                        isEmail ? WrapInMjml("Hi {Name}, thank you for joining us. We are excited to have you on board.")
-                                : "Hi {Name}, welcome to {AppName}! We are excited to have you on board."
+                        "Welcome to {{AppName}}!",
+                        isEmail ? WrapInMjml("Hi {{Name}}, thank you for joining us. We are excited to have you on board.")
+                                : "Hi {{Name}}, welcome to {{AppName}}! We are excited to have you on board."
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -50,8 +50,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         EventType.PasswordReset,
                         channel,
                         "Reset Your Password",
-                        isEmail ? WrapInMjml("Hello {Name}, use this code to reset your password: <b>{Code}</b>")
-                                : "Hello {Name}, your password reset code is: {Code}"
+                        isEmail ? WrapInMjml("Hello {{Name}}, use this code to reset your password: <b>{{Code}}</b>")
+                                : "Hello {{Name}}, your password reset code is: {{Code}}"
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -60,8 +60,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         EventType.EmailVerified,
                         channel,
                         "Email Verified Successfully",
-                        isEmail ? WrapInMjml("Hi {Name}, your email address has been verified. You can now access all features.")
-                                : "Hi {Name}, your email address has been verified. You can now access all features."
+                        isEmail ? WrapInMjml("Hi {{Name}}, your email address has been verified. You can now access all features.")
+                                : "Hi {{Name}}, your email address has been verified. You can now access all features."
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -70,8 +70,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         EventType.LoginAlert,
                         channel,
                         "New Login Detected",
-                        isEmail ? WrapInMjml("Hello {Name}, we detected a new login to your account from <b>{Device}</b> at <b>{Time}</b>.")
-                                : "Hello {Name}, we detected a new login to your account from {Device} at {Time}."
+                        isEmail ? WrapInMjml("Hello {{Name}}, we detected a new login to your account from <b>{{Device}}</b> at <b>{{Time}}</b>.")
+                                : "Hello {{Name}}, we detected a new login to your account from {{Device}} at {{Time}}."
                     ));
 
                     // --- E-COMMERCE EVENTS ---
@@ -80,9 +80,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Sent after a successful purchase, providing the customer with an order summary.",
                         EventType.OrderCreated,
                         channel,
-                        "Order Confirmation #{OrderId}",
-                        isEmail ? WrapInMjml("Dear {Name}, thank you for your order. Total amount: <b>{Amount}</b>.")
-                                : "Hi {Name}, order #{OrderId} for {Amount} is received."
+                        "Order Confirmation #{{OrderId}}",
+                        isEmail ? WrapInMjml("Dear {{Name}}, thank you for your order. Total amount: <b>{{Amount}}</b>.")
+                                : "Hi {{Name}}, order #{{OrderId}} for {{Amount}} is received."
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -90,9 +90,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Alerts the customer when their order has been dispatched and provides tracking info.",
                         EventType.OrderShipped,
                         channel,
-                        "Your Order Has Shipped! #{OrderId}",
-                        isEmail ? WrapInMjml("Great news {Name}! Your order is on its way. Tracking: {TrackingNumber}")
-                                : "Hi {Name}, order #{OrderId} is shipped! Tracking: {TrackingNumber}"
+                        "Your Order Has Shipped! #{{OrderId}}",
+                        isEmail ? WrapInMjml("Great news {{Name}}! Your order is on its way. Tracking: {{TrackingNumber}}")
+                                : "Hi {{Name}}, order #{OrderId} is shipped! Tracking: {{TrackingNumber}}"
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -101,8 +101,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         EventType.OrderDelivered,
                         channel,
                         "Order Delivered",
-                        isEmail ? WrapInMjml("Hi {Name}, your order #{OrderId} has been delivered. Enjoy!")
-                                : "Hi {Name}, your order #{OrderId} has been delivered. Enjoy!"
+                        isEmail ? WrapInMjml("Hi {{Name}}, your order #{{OrderId}} has been delivered. Enjoy!")
+                                : "Hi {{Name}}, your order #{{OrderId}} has been delivered. Enjoy!"
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -110,9 +110,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Urgent notification sent when a transaction fails, asking the user to update payment info.",
                         EventType.PaymentFailed,
                         channel,
-                        "Payment Failed for Order #{OrderId}",
-                        isEmail ? WrapInMjml("Hello {Name}, we couldn't process your payment. Please update your payment method to proceed.")
-                                : "Hello {Name}, we couldn't process your payment. Please update your payment method to proceed."
+                        "Payment Failed for Order #{{OrderId}}",
+                        isEmail ? WrapInMjml("Hello {{Name}}, we couldn't process your payment. Please update your payment method to proceed.")
+                                : "Hello {{Name}}, we couldn't process your payment. Please update your payment method to proceed."
                     ));
 
                     // --- GENERAL EVENTS ---
@@ -122,8 +122,8 @@ namespace FertileNotify.Infrastructure.Persistence
                         EventType.Campaign,
                         channel,
                         "{CampaignTitle}",
-                        isEmail ? WrapInMjml("Hi {Name}, check out our latest offer: {CampaignDetails}. Don't miss out!")
-                                : "Hi {Name}, check out our latest offer: {CampaignDetails}. Don't miss out!"
+                        isEmail ? WrapInMjml("Hi {{Name}}, check out our latest offer: {{CampaignDetails}}. Don't miss out!")
+                                : "Hi {{Name}}, check out our latest offer: {{CampaignDetails}}. Don't miss out!"
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -131,9 +131,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Sent monthly to keep users informed about platform updates and news.",
                         EventType.MonthlyNewsletter,
                         channel,
-                        "{Month} Newsletter",
-                        isEmail ? WrapInMjml("Hi {Name}, here are the updates for this month: <b>{Updates}.</b>")
-                                : "Hi {Name}, here are the updates for this month: {Updates}."
+                        "{{Month}} Newsletter",
+                        isEmail ? WrapInMjml("Hi {{Name}}, here are the updates for this month: <b>{{Updates}}.</b>")
+                                : "Hi {{Name}}, here are the updates for this month: {{Updates}}."
                     ));
 
                     globalTemplates.Add(NotificationTemplate.CreateGlobal(
@@ -141,9 +141,9 @@ namespace FertileNotify.Infrastructure.Persistence
                         "Notifies the user when there is a new response or status change on their support ticket.",
                         EventType.SupportTicketUpdated,
                         channel,
-                        "Update on Ticket #{TicketId}",
-                        isEmail ? WrapInMjml("Hello {Name}, your support ticket has been updated. <b>Status: {Status}. Reply: {Message}.</b>")
-                                : "Hello {Name}, your support ticket has been updated. Status: {Status}. Reply: {Message}."
+                        "Update on Ticket #{{TicketId}}",
+                        isEmail ? WrapInMjml("Hello {{Name}}, your support ticket has been updated. <b>Status: {{Status}}. Reply: {{Message}}.</b>")
+                                : "Hello {{Name}}, your support ticket has been updated. Status: {Status}. Reply: {{Message}}."
                     ));
                 }
 

--- a/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
+++ b/backend/FertileNotify.Infrastructure/Persistence/EfNotificationLogRepository.cs
@@ -20,21 +20,37 @@ namespace FertileNotify.Infrastructure.Persistence
         }
 
         public async Task<List<NotificationLog>> GetLatestBySubscriberIdAsync(Guid subscriberId, int count)
-        {
-            return await _context.Set<NotificationLog>()
+            => await _context.Set<NotificationLog>()
                 .AsNoTracking()
                 .Where(l => l.SubscriberId == subscriberId)
                 .OrderByDescending(l => l.CreatedAt)
                 .Take(count)
                 .ToListAsync();
-        }
 
         public async Task<List<NotificationLog>> GetLogsForStatsAsync(Guid subscriberId, DateTime startDate)
-        {
-            return await _context.NotificationLogs
+            => await _context.NotificationLogs
                 .Where(l => l.SubscriberId == subscriberId && l.CreatedAt >= startDate)
                 .AsNoTracking()
                 .ToListAsync();
+
+        public async Task<List<NotificationLog>> GetLogsForAnonymizationAsync(DateTime cutOffDate)
+            => await _context.Set<NotificationLog>()
+                .Where(l => l.CreatedAt <= cutOffDate)
+                .ToListAsync();
+
+        public async Task UpdateRangeAsync(IEnumerable<NotificationLog> logs)
+        {
+            _context.Set<NotificationLog>().UpdateRange(logs);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteLogsOlderThanAsync(DateTime cutOffDate)
+        {
+            var logsToDelete = _context.Set<NotificationLog>()
+                .Where(l => l.CreatedAt <= cutOffDate);
+            
+            _context.Set<NotificationLog>().RemoveRange(logsToDelete);
+            await _context.SaveChangesAsync();
         }
     }
 }


### PR DESCRIPTION
Introduce notification logging and GDPR retention features: add INotificationLogService and NotificationLogService to encapsulate logging of successes, failures and rejections; register service in DI. Add LogRetentionWorker background service (registered) to delete logs older than 30 days and anonymize logs older than 7 days. Extend INotificationLogRepository with methods for anonymization, batch update and deletion; implement these in EfNotificationLogRepository. Add anonymization and rejection support to NotificationLog and DeliveryStatus enum. Update SendNotificationHandler to delegate logging to the new service and to handle business/processing errors, remove inline finalization logic. Fix template variable handling (TemplateEngine and seeded templates) to use {{Var}} style placeholders. Remove direct DB logging from ConsoleNotificationSender (logging now centralized).