### PR TITLE
🧪 Add unit tests for NotificationTemplate entity

### DIFF
--- a/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
+++ b/backend/FertileNotify.Domain/Entities/NotificationTemplate.cs
@@ -1,4 +1,5 @@
-﻿using FertileNotify.Domain.Events;
+using System;
+using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 
 namespace FertileNotify.Domain.Entities
@@ -38,7 +39,6 @@ namespace FertileNotify.Domain.Entities
         {
             Name = name;
             Description = description;
-
             Subject = subject;
             Body = body;
         }

--- a/backend/FertileNotify.Tests/NotificationTemplateTests.cs
+++ b/backend/FertileNotify.Tests/NotificationTemplateTests.cs
@@ -1,0 +1,99 @@
+using FertileNotify.Domain.Entities;
+using FertileNotify.Domain.Events;
+using FertileNotify.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace FertileNotify.Tests
+{
+    public class NotificationTemplateTests
+    {
+        [Fact]
+        public void CreateGlobal_Should_InitializePropertiesCorrectly()
+        {
+            // Arrange
+            var name = "Welcome Email";
+            var description = "Standard welcome message for new subscribers";
+            var eventType = EventType.SubscriberRegistered;
+            var channel = NotificationChannel.Email;
+            var subject = "Welcome to our service!";
+            var body = "Hi {{name}}, thanks for joining!";
+
+            // Act
+            var template = NotificationTemplate.CreateGlobal(name, description, eventType, channel, subject, body);
+
+            // Assert
+            template.Id.Should().NotBeEmpty();
+            template.SubscriberId.Should().BeNull();
+            template.Name.Should().Be(name);
+            template.Description.Should().Be(description);
+            template.EventType.Should().Be(eventType);
+            template.Channel.Should().Be(channel);
+            template.Subject.Should().Be(subject);
+            template.Body.Should().Be(body);
+        }
+
+        [Fact]
+        public void CreateCustom_Should_InitializePropertiesCorrectly()
+        {
+            // Arrange
+            var subscriberId = Guid.NewGuid();
+            var name = "Custom Order Notification";
+            var description = "A custom notification for a specific subscriber's orders";
+            var eventType = EventType.OrderCreated;
+            var channel = NotificationChannel.SMS;
+            var subject = "Your Order is Confirmed";
+            var body = "Your order #{{orderId}} is being processed.";
+
+            // Act
+            var template = NotificationTemplate.CreateCustom(subscriberId, name, description, eventType, channel, subject, body);
+
+            // Assert
+            template.Id.Should().NotBeEmpty();
+            template.SubscriberId.Should().Be(subscriberId);
+            template.Name.Should().Be(name);
+            template.Description.Should().Be(description);
+            template.EventType.Should().Be(eventType);
+            template.Channel.Should().Be(channel);
+            template.Subject.Should().Be(subject);
+            template.Body.Should().Be(body);
+        }
+
+        [Fact]
+        public void Update_Should_ModifyOnlySpecificProperties()
+        {
+            // Arrange
+            var template = NotificationTemplate.CreateGlobal(
+                "Initial Name",
+                "Initial Description",
+                EventType.TestForDevelop,
+                NotificationChannel.Console,
+                "Initial Subject",
+                "Initial Body"
+            );
+
+            var initialId = template.Id;
+            var initialEventType = template.EventType;
+            var initialChannel = template.Channel;
+
+            var updatedName = "Updated Name";
+            var updatedDescription = "Updated Description";
+            var updatedSubject = "Updated Subject";
+            var updatedBody = "Updated Body";
+
+            // Act
+            template.Update(updatedName, updatedDescription, updatedSubject, updatedBody);
+
+            // Assert
+            template.Name.Should().Be(updatedName);
+            template.Description.Should().Be(updatedDescription);
+            template.Subject.Should().Be(updatedSubject);
+            template.Body.Should().Be(updatedBody);
+
+            // Properties that should NOT change
+            template.Id.Should().Be(initialId);
+            template.SubscriberId.Should().BeNull();
+            template.EventType.Should().Be(initialEventType);
+            template.Channel.Should().Be(initialChannel);
+        }
+    }
+}

--- a/backend/FertileNotify.Tests/NotificationTemplateTests.cs
+++ b/backend/FertileNotify.Tests/NotificationTemplateTests.cs
@@ -1,7 +1,9 @@
+using System;
 using FertileNotify.Domain.Entities;
 using FertileNotify.Domain.Events;
 using FertileNotify.Domain.ValueObjects;
 using FluentAssertions;
+using Xunit;
 
 namespace FertileNotify.Tests
 {
@@ -19,7 +21,7 @@ namespace FertileNotify.Tests
             var body = "Hi {{name}}, thanks for joining!";
 
             // Act
-            var template = NotificationTemplate.CreateGlobal(name, description, eventType, channel, subject, body);
+            var template = FertileNotify.Domain.Entities.NotificationTemplate.CreateGlobal(name, description, eventType, channel, subject, body);
 
             // Assert
             template.Id.Should().NotBeEmpty();
@@ -45,7 +47,7 @@ namespace FertileNotify.Tests
             var body = "Your order #{{orderId}} is being processed.";
 
             // Act
-            var template = NotificationTemplate.CreateCustom(subscriberId, name, description, eventType, channel, subject, body);
+            var template = FertileNotify.Domain.Entities.NotificationTemplate.CreateCustom(subscriberId, name, description, eventType, channel, subject, body);
 
             // Assert
             template.Id.Should().NotBeEmpty();
@@ -62,7 +64,7 @@ namespace FertileNotify.Tests
         public void Update_Should_ModifyOnlySpecificProperties()
         {
             // Arrange
-            var template = NotificationTemplate.CreateGlobal(
+            var template = FertileNotify.Domain.Entities.NotificationTemplate.CreateGlobal(
                 "Initial Name",
                 "Initial Description",
                 EventType.TestForDevelop,


### PR DESCRIPTION
🎯 **What:** The testing gap for the `NotificationTemplate` domain entity has been addressed by adding a comprehensive suite of unit tests.

📊 **Coverage:** The new tests in `NotificationTemplateTests.cs` cover the following scenarios:
- **Global Template Creation:** Asserts that `CreateGlobal` correctly initializes all properties and sets `SubscriberId` to null.
- **Custom Template Creation:** Asserts that `CreateCustom` correctly initializes all properties and assigns the provided `SubscriberId`.
- **State Updates:** Verifies that the `Update` method only modifies the allowed fields (`Name`, `Description`, `Subject`, `Body`) while preserving critical identifiers and metadata (`Id`, `SubscriberId`, `EventType`, `Channel`).

✨ **Result:** This improvement increases the reliability of the core domain logic for notification templates, ensuring that any future refactoring of the entity can be done with confidence.

---
*PR created automatically by Jules for task [14214681710866605006](https://jules.google.com/task/14214681710866605006) started by @EnesEfeTokta*